### PR TITLE
fix: Change argument types from Map<String, String> to Map<String, dynamic>

### DIFF
--- a/lib/src/convex_client.dart
+++ b/lib/src/convex_client.dart
@@ -164,7 +164,7 @@ class ConvexClient {
   ///
   /// Returns the query result as a JSON string.
   /// Throws [TimeoutException] if the operation exceeds [config.operationTimeout].
-  Future<String> query(String name, Map<String, String> args) =>
+  Future<String> query(String name, Map<String, dynamic> args) =>
       _impl.query(name, args);
 
   /// Executes a Convex mutation operation with timeout.
@@ -178,7 +178,7 @@ class ConvexClient {
     required String name,
     required Map<String, dynamic> args,
   }) =>
-      _impl.mutation(name: name, args: args.map((k, v) => MapEntry(k, v.toString())));
+      _impl.mutation(name: name, args: args);
 
   /// Executes a Convex action operation with timeout.
   ///
@@ -191,7 +191,7 @@ class ConvexClient {
     required String name,
     required Map<String, dynamic> args,
   }) =>
-      _impl.action(name: name, args: args.map((k, v) => MapEntry(k, v.toString())));
+      _impl.action(name: name, args: args);
 
   /// Creates a real-time subscription to a Convex query.
   ///
@@ -203,7 +203,7 @@ class ConvexClient {
   /// Returns a handle that can be used to cancel the subscription.
   Future<SubscriptionHandle> subscribe({
     required String name,
-    required Map<String, String> args,
+    required Map<String, dynamic> args,
     required void Function(String) onUpdate,
     required void Function(String, String?) onError,
   }) =>

--- a/lib/src/impl/convex_client_interface.dart
+++ b/lib/src/impl/convex_client_interface.dart
@@ -31,7 +31,7 @@ abstract class IConvexClient {
   /// Throws:
   /// - [TimeoutException] if operation exceeds configured timeout
   /// - [ClientError] for Convex-specific errors
-  Future<String> query(String name, Map<String, String> args);
+  Future<String> query(String name, Map<String, dynamic> args);
 
   /// Executes a Convex mutation operation.
   ///
@@ -45,7 +45,7 @@ abstract class IConvexClient {
   /// - [ClientError] for Convex-specific errors
   Future<String> mutation({
     required String name,
-    required Map<String, String> args,
+    required Map<String, dynamic> args,
   });
 
   /// Executes a Convex action operation.
@@ -60,7 +60,7 @@ abstract class IConvexClient {
   /// - [ClientError] for Convex-specific errors
   Future<String> action({
     required String name,
-    required Map<String, String> args,
+    required Map<String, dynamic> args,
   });
 
   /// Creates a real-time subscription to a Convex query.
@@ -73,7 +73,7 @@ abstract class IConvexClient {
   /// Returns a handle that can be used to cancel the subscription.
   Future<SubscriptionHandle> subscribe({
     required String name,
-    required Map<String, String> args,
+    required Map<String, dynamic> args,
     required void Function(String) onUpdate,
     required void Function(String, String?) onError,
   });

--- a/lib/src/impl/convex_client_native.dart
+++ b/lib/src/impl/convex_client_native.dart
@@ -111,7 +111,7 @@ class NativeConvexClient implements IConvexClient {
   // ============================================================================
 
   @override
-  Future<String> query(String name, Map<String, String> args) async {
+  Future<String> query(String name, Map<String, dynamic> args) async {
     final formattedArgs = buildArgs(args);
     return await _rustClient
         .query(name: name, args: formattedArgs)
@@ -121,7 +121,7 @@ class NativeConvexClient implements IConvexClient {
   @override
   Future<String> mutation({
     required String name,
-    required Map<String, String> args,
+    required Map<String, dynamic> args,
   }) async {
     final formattedArgs = buildArgs(args);
     return await _rustClient
@@ -132,7 +132,7 @@ class NativeConvexClient implements IConvexClient {
   @override
   Future<String> action({
     required String name,
-    required Map<String, String> args,
+    required Map<String, dynamic> args,
   }) async {
     final formattedArgs = buildArgs(args);
     return await _rustClient
@@ -143,7 +143,7 @@ class NativeConvexClient implements IConvexClient {
   @override
   Future<SubscriptionHandle> subscribe({
     required String name,
-    required Map<String, String> args,
+    required Map<String, dynamic> args,
     required void Function(String) onUpdate,
     required void Function(String, String?) onError,
   }) async {

--- a/lib/src/impl/convex_client_web.dart
+++ b/lib/src/impl/convex_client_web.dart
@@ -456,7 +456,7 @@ class WebConvexClient implements IConvexClient {
   // ============================================================================
 
   @override
-  Future<String> query(String name, Map<String, String> args) async {
+  Future<String> query(String name, Map<String, dynamic> args) async {
     // Queries in Convex protocol use ModifyQuerySet (like subscriptions)
     // We subscribe, wait for first result, then unsubscribe
     final queryId = _queryIdCounter++;
@@ -517,7 +517,7 @@ class WebConvexClient implements IConvexClient {
   @override
   Future<String> mutation({
     required String name,
-    required Map<String, String> args,
+    required Map<String, dynamic> args,
   }) async {
     final requestId = _generateMessageId();
     final completer = Completer<String>();
@@ -548,7 +548,7 @@ class WebConvexClient implements IConvexClient {
   @override
   Future<String> action({
     required String name,
-    required Map<String, String> args,
+    required Map<String, dynamic> args,
   }) async {
     final requestId = _generateMessageId();
     final completer = Completer<String>();
@@ -579,7 +579,7 @@ class WebConvexClient implements IConvexClient {
   @override
   Future<SubscriptionHandle> subscribe({
     required String name,
-    required Map<String, String> args,
+    required Map<String, dynamic> args,
     required void Function(String) onUpdate,
     required void Function(String, String?) onError,
   }) async {


### PR DESCRIPTION
## Summary
  - Changed all argument types from `Map<String, String>` to `Map<String, dynamic>` across query, mutation, action and subscribe methods
  - Fix applied consistently across all layers: public API, interface, native and web implementations
  - Removed `toString()` conversion in `mutation()` and `action()` that silently destroyed nested argument structures

  Closes #15

  ## Test plan
  - [ ] Verify passing nested objects (e.g. `paginationOpts`) to query/mutation/action/subscribe
  - [ ] Verify existing string-only arguments still work
  - [ ] Test on both native and web platforms