### PR TITLE
fix: bump convex rust client to 0.10.3 to fix reconnect loop

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "convex"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e7ab85cfc76e9a13d252da8a7933ab52f38b9c51de3f7bb8dbe4e2262bac04"
+checksum = "c154dd74ee30e7c1757486657f5c6e961f3ad183cd490c1e71dab58b0ad0717f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "convex_sync_types"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f819ce8fd4370f235f2f5e345499fa219d7d1827cd88923f1fa42942853604a0"
+checksum = "4089e2bd007e883e8a7a2ee44c3550969f15d471b7ec9c06976e91f1193cd0e3"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -1264,7 +1264,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1508,7 +1508,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1632,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -1694,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ flutter_rust_bridge = "=2.11.1"
 tokio = { version = "1", features = ["full"] }
 android_logger = { version = "0.14.1" }
 log = { version = "0.4.21" }
-convex = { version = "0.10", features = ["rustls-tls-webpki-roots"] }
+convex = { version = "0.10.3", features = ["rustls-tls-webpki-roots"] }
 anyhow = { version = "1.0.86" }
 thiserror = { version = "1.0.61" }
 tokio-stream = { features = [ "io-util", "sync" ], version = "0.1" }


### PR DESCRIPTION
## Summary
Bump the Rust `convex` dependency from `0.10` to `0.10.3`.

This fixes a reconnect instability issue seen after network/lifecycle interruptions, where the client can enter a reconnect loop and hit protocol errors like:

- `FatalError: Base version 0 passed up doesn't match the current version 1`
- repeated `ProtocolFailure` / reconnect flapping

I encountered this while integrating [Clerk](https://pub.dev/packages/clerk_flutter) with Convex in my Flutter app and this was the only way to fix the issue and seems like a trivial and appropriate upgrade to `convex_flutter`.

## Convex Rust references
- Convex Rust issue: https://github.com/get-convex/convex-rs/issues/14
- Fix commit in `convex-rs`: https://github.com/get-convex/convex-rs/commit/65deb8a1eb793c1c7482837085f3bc2c8522c4b8
- Included in `0.10.3` release line: https://github.com/get-convex/convex-rs/commit/9fef2d7

## Changes
- `rust/Cargo.toml`: `convex = "0.10.3"`
- `rust/Cargo.lock`: updated transitive lock entries (`convex`, `convex_sync_types`, `tokio-tungstenite`, `tungstenite`)

## Validation
- `cargo check --manifest-path rust/Cargo.toml` passes 
- Verified Rust crate compiles and that my Flutter app build succeeds on macOS, iOS and Android. Used a dependency override in pubspec pointing to my fork with this commit.
  ```
  dependency_overrides:
    convex_flutter:
      git:
        url: https://github.com/SasLuca/convex_flutter.git
        ref: c94323c
  ```
- Reconnect behavior validated in my Flutter app with auth + background/resume + airplane mode toggles

## AI usage disclosure
I encountered this issue while coding a Flutter app using `gpt-5.3-codex-xhigh` and used it heavily to debug and fix it. I have professional experience with Flutter and I analyzed the issue and suggested fix to make sure it is valid in my view.