### PR TITLE
chore: bump convex Rust SDK to 0.10.4 + prep 3.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## 3.0.2
+
+### Bug Fixes
+
+- **Fix WebSocket reconnect leaving the client in an incorrect state**:
+  - Bumped Rust `convex` SDK from `0.10.2` → `0.10.4`. The `0.10.3`
+    release of `convex-rs` ships "Fix for incorrect client state on
+    WebSocket reconnect" — pending mutations were not being drained on
+    reconnect, so back-to-back signup/signout cycles in a single
+    process could wedge subsequent mutations indefinitely. Process
+    restart used to be the only workaround. (PR #17 by @SasLuca, 2026-02)
+  - `0.10.4` additionally fixes a memory leak in query subscriptions
+    (`convex-rs` issue #15) — relevant to apps that subscribe to many
+    Convex queries over a long-running session.
+
+### Improvements
+
+- Argument types for queries / mutations / actions are now
+  `Map<String, dynamic>` instead of `Map<String, String>`. Lets you
+  pass numbers, booleans, lists, and nested objects directly without
+  manual JSON encoding. (PR #16 by @igoriuz)
+
+### Compatibility
+
+- No public Dart API changes — `3.0.2` is a drop-in upgrade from `3.0.1`.
+- Rust crate `convex` now requires Rust 1.85 or newer (per upstream
+  `convex-rs` 0.10.4). Affects only contributors building the FFI
+  binaries from source; end-user apps consume precompiled binaries.
+
 ## 3.0.0
 
 ### Major New Features

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: convex_flutter
 description: Multi-platform Convex backend integration for Flutter. Real-time WebSocket, subscriptions, auth, lifecycle management. Supports web (pure Dart) and native.
-version: 3.0.0
+version: 3.0.2
 repository: https://github.com/jkuldev/convex_flutter
 homepage: https://jkuldev.com
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "convex"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c154dd74ee30e7c1757486657f5c6e961f3ad183cd490c1e71dab58b0ad0717f"
+checksum = "4ca2fbc7cfc35747ade0731b173cf72c70c7f72c4578440f9a77c871adaa1e2f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "convex_sync_types"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4089e2bd007e883e8a7a2ee44c3550969f15d471b7ec9c06976e91f1193cd0e3"
+checksum = "cba8235188b091cc50205a436bf6505cb386be208263fecdb4b62bd2b3c90a0a"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "imbl"
-version = "5.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4308a675e4cfc1920f36a8f4d8fb62d5533b7da106844bd1ec51c6f1fa94a0c"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
 dependencies = [
  "archery",
  "bitmaps",
@@ -823,6 +823,7 @@ dependencies = [
  "rand_core",
  "rand_xoshiro",
  "version_check",
+ "wide",
 ]
 
 [[package]]
@@ -1305,6 +1306,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "schannel"
@@ -1890,6 +1900,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ flutter_rust_bridge = "=2.11.1"
 tokio = { version = "1", features = ["full"] }
 android_logger = { version = "0.14.1" }
 log = { version = "0.4.21" }
-convex = { version = "0.10.3", features = ["rustls-tls-webpki-roots"] }
+convex = { version = "0.10.4", features = ["rustls-tls-webpki-roots"] }
 anyhow = { version = "1.0.86" }
 thiserror = { version = "1.0.61" }
 tokio-stream = { features = [ "io-util", "sync" ], version = "0.1" }


### PR DESCRIPTION
## Summary

Bumps the Rust `convex` dependency from `0.10.3` → `0.10.4` (latest) and prepares a `3.0.2` release so the WebSocket-reconnect fix already merged in #17 (and the `Map<String, dynamic>` arg-types fix in #16) finally land on pub.dev.

## What changed

| File | Change |
|---|---|
| `rust/Cargo.toml` | `convex = "0.10.3"` → `"0.10.4"` |
| `rust/Cargo.lock` | Regenerated via `cargo update -p convex` |
| `pubspec.yaml` | `version: 3.0.0` → `version: 3.0.2` (3.0.1 is already published; the repo's `pubspec.yaml` was never bumped to match it, so 3.0.2 is the next available pub.dev slot) |
| `CHANGELOG.md` | New top-level `## 3.0.2` section summarising everything accumulated since `3.0.1` was published |

## Why 0.10.4 over 0.10.3

- **0.10.3** (already merged via #17) ships *"Fix for incorrect client state on WebSocket reconnect"* — pending mutations weren't drained on reconnect, so back-to-back signup/signout cycles in a single process could wedge subsequent mutations indefinitely. We hit this in our Flutter E2E test suite where the only workaround was a process restart.
- **0.10.4** additionally fixes a memory leak in query subscriptions ([`convex-rs` issue #15](https://github.com/get-convex/convex-rs/issues/15)) and tightens `check_valid_field_name` in `sync_types`. Apps that subscribe to many Convex queries over a long-running session benefit most.

Both upstream changelog entries:
> ## 0.10.4
> - Optimizations to `check_valid_field_name` in `sync_types`
> - Fix for memory leak in query subscriptions
> - Bump rust-version minimum from 1.80.1 to 1.85
>
> ## 0.10.3
> - Fix for incorrect client state on WebSocket reconnect
> - New `set_auth_callback` method on `ConvexClient` to allow token refresh on WebSocket reconnect

## Compatibility

- **No public Dart API changes.** `3.0.2` is a drop-in upgrade from `3.0.1`.
- `convex-rs 0.10.4` raises the Rust MSRV to `1.85`. Affects only contributors building the FFI binaries from source — end-user apps consume the precompiled cargokit binaries.

## Verification

Walked through `CONTRIBUTING.md`'s "Test Checklist for Pull Requests" (lines 300–311) and pre-submission steps (lines 152–164). Status of each, scoped honestly to *this* PR:

**Build / link verification (the load-bearing checks for a dependency bump):**
- ✅ `cd rust && cargo check` — clean on Linux.
- ✅ `cd rust && cargo build --release` — clean. `convex_flutter` cdylib + staticlib link successfully against `convex 0.10.4`. `convex_sync_types` and `imbl` (major bump) compile.
- ✅ `cargo tree -p convex --depth 0` confirms `convex v0.10.4` resolved.
- ✅ `flutter pub get` succeeds with the new `version: 3.0.2`.
- ✅ Lockfile bump scope verified — only `convex`, `convex_sync_types`, `imbl`, plus new transitives `safe_arch` and `wide` (pulled in by the new `imbl` major).

**Existing tests:**
- N/A — the package root has no `test/` directory, so `flutter test` reports *"Test directory 'test' not found."* This is a pre-existing repo state (true on `main` as well), not something this PR introduced or removed.

**Formatter / analyzer:**
- `flutter analyze` — 88 issues exist, but **none are introduced by this PR** (no Dart files modified). All are pre-existing in `cargokit/build_tool/` (vendored, dependency-resolution issues with `package:ed25519_edwards`/`package:hex`/`package:github`), `example/lib/screens/`, and `rust/example/lib/main.dart`.
- `dart format --set-exit-if-changed .` — would rewrite **27 pre-existing files** none of which this PR touches. Reverted locally to keep the diff scoped to the dependency bump. Happy to follow up with a separate "format upstream drift" PR if maintainers want.
- `cargo fmt --check` — drift exists only in `rust/src/lib.rs`, which this PR does not modify. Same scope rationale as above.

**Manual platform testing (CONTRIBUTING.md lines 306–308 — at least one native platform for native changes):**
- ❌ **Not performed.** The two upstream behavioural changes (memory leak in long-running subscriptions; protocol validation in `check_valid_field_name`) only surface in multi-hour subscription sessions against a live Convex backend, which I don't have provisioned for this fork. The release build linking cleanly + no public-API delta is the strongest signal I can give from a fork. If a maintainer wants a runtime smoke test before merging, I can wire a short subscription loop into `example/` and post a log — happy to do that as a follow-up commit.

**Other checklist items:**
- ✅ `CHANGELOG.md` updated.
- ✅ No public Dart API changes (drop-in upgrade).
- ✅ No documentation updates needed (no API surface change).

## Notes for the maintainer

The `3.0.2` version bump is intentionally pre-baked so that once this is merged the next `flutter pub publish` ships the accumulated fixes directly. Happy to split into a separate "release-prep" commit if that's preferred.
