### PR TITLE
patch: web — survive Flutter hot-restart by disposing prior client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.0.1
+
+### Bug Fixes
+
+- **Fixed argument types from `Map<String, String>` to `Map<String, dynamic>`** across all operations (query, mutation, action, subscribe)
+  - Nested objects (e.g., `paginationOpts`), arrays, numbers, and booleans are now properly supported as argument values
+  - Fix applied consistently across public API, interface, native, and web implementations
+  - Removed `toString()` conversion in mutation and action that silently destroyed nested argument structures
+  - Closes #15
+
 ## 3.0.0
 
 ### Major New Features

--- a/VENDOR_CHANGES.md
+++ b/VENDOR_CHANGES.md
@@ -1,0 +1,171 @@
+# Invyte patches on top of upstream convex_flutter
+
+This fork sits on top of [jkuldev/convex_flutter](https://github.com/jkuldev/convex_flutter)
+`main` (post-PR #17 — `convex` 0.10.3 + `Map<String, dynamic>` args). Each section
+below corresponds to a discrete commit on this branch; refer to `git log` for
+exact contents. Upstream issue tracking Android WSS failure:
+[#18](https://github.com/jkuldev/convex_flutter/issues/18).
+
+## Cargokit (`cargokit/`)
+
+### Skip debug x86 + x86_64 force-add on Android
+
+**cargokit/gradle/plugin.gradle** — upstream mirrors `flutter.gradle` by
+force-adding `android-x86` and `android-x64` to the debug target list, so
+`cargo build` runs for three architectures even when the connected device is
+arm64. Invyte ships arm64-v8a only (see `app/android/app/build.gradle.kts`
+`ndk.abiFilters`), and dev/test happens on physical arm64 devices via the
+WSL2→Windows ADB bridge. The extra cross-compiles added ~60–90s per debug
+iteration. The block is replaced with a comment; to re-enable emulator builds,
+restore the upstream lines or pass `--target-platform=android-x64`.
+
+## Rust client (`rust/`)
+
+### TLS: disable default `native-tls-vendored` feature
+
+**Cargo.toml** — `convex` dependency changed to `default-features = false`.
+
+The `convex` crate's default features enable `native-tls-vendored`, which compiles
+OpenSSL from source. When combined with our explicit `rustls-tls-webpki-roots`
+feature, both TLS backends are linked into `tokio-tungstenite`. At runtime,
+`tokio-tungstenite` prefers `native-tls` when both are present — and vendored
+OpenSSL cannot resolve CA certificates on Android, causing WSS handshakes to fail
+silently (the connection stays in "connecting" forever).
+
+Setting `default-features = false` ensures only `rustls` (pure Rust, bundled
+Mozilla CA certs) is compiled. No OpenSSL dependency.
+
+### Logging: tracing → logcat bridge
+
+**Cargo.toml** — added `tracing` with `log` feature.
+
+**lib.rs** — replaced `println!` (goes to `/dev/null` on Android) with
+`log::debug!` / `log::error!` calls. The `tracing` crate's `log` feature
+causes tracing events (used by the Convex SDK for connection errors, backoff,
+and reconnect diagnostics) to automatically fall through to the `log` crate
+when no tracing subscriber is installed. `android_logger` then forwards
+everything to logcat.
+
+Log level is controlled by the `verbose_logging` flag passed from Dart's
+`ConvexConfig.debugLogging`: verbose = Debug (all messages), normal = Warn
+(only warnings and errors).
+
+### Verbose logging flag
+
+**lib.rs** — `MobileConvexClient::new()` accepts a `verbose_logging: bool`
+parameter that controls `android_logger` max level.
+
+**lib/src/convex_config.dart** — added a `debugLogging` field on
+`ConvexConfig` (defaults to `false`) so consumers can drive verbose mode
+from `kDebugMode`. The Dart wrapper (`NativeConvexClient`) passes it
+through to the Rust constructor and gates all informational `debugPrint`
+calls behind it. Error-level logs are always printed.
+
+### Cross-transport number normalisation
+
+**lib/src/utils.dart** — added `normalizeJsonNumbers()` helper.
+
+Dart's `jsonDecode` preserves `1` (int) vs `1.0` (double). The web client
+delivers integers for whole numbers, but the Rust FFI client serialises
+all Convex `Float64` values with a decimal point. This mismatch causes
+`as int` casts in consumer DTOs to throw on mobile. The native client now
+post-processes results through `normalizeJsonNumbers` so consumers see
+the same Dart types regardless of transport.
+
+### Bump Convex SDK
+
+**Cargo.toml** — `convex` bumped from `0.7.0` to `0.10.4`.
+
+- `0.10.3` (upstream PR #331): newer protocol support, `WebSocketState`
+  callback API, reconnect-loop fix that prevented `Base version 0 passed up
+  doesn't match the current version 1` after lifecycle interruptions.
+- `0.10.4`: fix for memory leak in query subscriptions
+  ([convex-rs#15](https://github.com/get-convex/convex-rs/issues/15)) —
+  `BaseConvexClient` retained cached `FunctionResult` entries after the final
+  unsubscribe. Long-lived sessions with many distinct subscriptions (Invyte's
+  exact shape: events, chat, live) accumulated ~8 KB per query result. Also
+  raises Rust MSRV to 1.85; pulls in `imbl` 7.0 (major bump) and new
+  transitives `safe_arch` + `wide`. Mirrors upstream PR #20.
+
+## Web client (`lib/src/impl/convex_client_web.dart`)
+
+All patches listed in the file header comment (patches 1–9):
+
+### 1. Auth message format
+
+`_sendAuthMessage` — corrected `Authenticate` message to use the
+`tokenType`/`value`/`baseVersion` structure expected by the Convex protocol.
+
+### 2. Sign-out sends null token
+
+`setAuth` — pass `null` instead of `''` for sign-out so `tokenType:"None"` is
+sent to the server.
+
+### 3. Message queueing during connect
+
+`_sendMessage` — queue messages when the WebSocket is still in `CONNECTING`
+state. Queued messages are flushed automatically once the connection opens.
+Fixes a startup race where operations issued before the handshake completed
+were silently lost.
+
+### 4. Void-returning function results
+
+`_handleMutationResponse` / `_handleActionResponse` — check the `success` flag
+before treating a `null` result as an error. Void-returning Convex functions
+legitimately return `null`.
+
+### 5. Structured error types
+
+`_handleMutationResponse` / `_handleActionResponse` — emit `ClientError`
+(`convexError` or `serverError` variants) instead of generic `Exception`,
+matching the error types produced by the native FFI client.
+
+### 6. Separate identity version counter
+
+`_sendAuthMessage` — use a dedicated `_identityVersion` counter (not
+`_querySetVersion`) for the `Authenticate` message's `baseVersion`. The Convex
+protocol tracks query-set and identity versions independently.
+
+### 7. Deliver null subscription values
+
+`_handleTransition` — forward `null` `QueryUpdated` values to subscribers
+(e.g. a query returning `null` for an unauthenticated user). Previously only
+non-null values were delivered.
+
+### 8. Query-set version sync on reconnect
+
+`onopen` handler — sync `_querySetVersion` after flushing queued
+`ModifyQuerySet` messages so the local counter stays consistent with what the
+server has processed.
+
+### 9. Debug logging gating
+
+All informational `debugPrint` calls gated behind `config.debugLogging`.
+Error-level logs are always printed.
+
+### 10. Subscription error handling
+
+Added error-field parsing for subscription transition messages. The Convex
+protocol may send `errorMessage`, `error_message`, `errorData`, or `error` keys
+when a subscribed query fails. Previously these were silently ignored (the
+update callback was never called). Now errors are forwarded to
+`subscription.onError()`.
+
+Also added a diagnostic log when a transition message contains neither `value`
+nor an error field.
+
+### 11. `setAuthWithRefresh` — initialToken parameter and auto-refresh
+
+Added `initialToken` optional parameter to `setAuthWithRefresh` across the
+interface, native client, and web client. When provided, the web client uses the
+token directly for the initial `Authenticate` message instead of calling
+`tokenFetcher()`, which would consume the single-use refresh token and cause
+"Invalid refresh token" errors.
+
+Also wired up automatic token refresh on the web client: when the server sends
+an `AuthError` (emitted as `false` on `_authStateController`), the web client
+calls `tokenFetcher()` to obtain a new JWT and re-authenticates. The
+subscription is cancelled when the auth handle is disposed.
+
+The native client accepts the parameter for interface compliance but ignores it
+— the Rust SDK manages the initial fetch and refresh lifecycle internally.

--- a/VENDOR_CHANGES.md
+++ b/VENDOR_CHANGES.md
@@ -1,10 +1,14 @@
 # Invyte patches on top of upstream convex_flutter
 
 This fork sits on top of [jkuldev/convex_flutter](https://github.com/jkuldev/convex_flutter)
-`main` (post-PR #17 — `convex` 0.10.3 + `Map<String, dynamic>` args). Each section
-below corresponds to a discrete commit on this branch; refer to `git log` for
-exact contents. Upstream issue tracking Android WSS failure:
-[#18](https://github.com/jkuldev/convex_flutter/issues/18).
+`main` (post-PR #17 — `convex` 0.10.3 + `Map<String, dynamic>` args). Each
+section below covers a discrete area of divergence from upstream; refer to
+`git log` for exact commit boundaries. Upstream issue tracking the Android
+WSS failure: [#18](https://github.com/jkuldev/convex_flutter/issues/18).
+
+The fork is intentionally shaped to Invyte's needs (single-app downstream,
+arm64-only mobile target, integration with a `package:logging` consumer).
+Upstreaming is not a goal.
 
 ## Cargokit (`cargokit/`)
 
@@ -23,21 +27,23 @@ restore the upstream lines or pass `--target-platform=android-x64`.
 
 ### TLS: disable default `native-tls-vendored` feature
 
-**Cargo.toml** — `convex` dependency changed to `default-features = false`.
+**Cargo.toml** — `convex` dependency changed to `default-features = false`,
+explicit `rustls = "0.23"` with the `"ring"` provider added.
 
-The `convex` crate's default features enable `native-tls-vendored`, which compiles
-OpenSSL from source. When combined with our explicit `rustls-tls-webpki-roots`
-feature, both TLS backends are linked into `tokio-tungstenite`. At runtime,
-`tokio-tungstenite` prefers `native-tls` when both are present — and vendored
-OpenSSL cannot resolve CA certificates on Android, causing WSS handshakes to fail
-silently (the connection stays in "connecting" forever).
+The `convex` crate's default features enable `native-tls-vendored`, which
+compiles OpenSSL from source. When combined with our explicit
+`rustls-tls-webpki-roots` feature, both TLS backends are linked into
+`tokio-tungstenite`. At runtime, `tokio-tungstenite` prefers `native-tls`
+when both are present — and vendored OpenSSL cannot resolve CA certificates
+on Android, causing WSS handshakes to fail silently (the connection stays
+in "connecting" forever).
 
-Setting `default-features = false` ensures only `rustls` (pure Rust, bundled
-Mozilla CA certs) is compiled. No OpenSSL dependency.
+Setting `default-features = false` plus the explicit rustls pin ensures
+only rustls (pure Rust, bundled Mozilla CA certs) is compiled. No OpenSSL.
 
 ### Logging: tracing → logcat bridge
 
-**Cargo.toml** — added `tracing` with `log` feature.
+**Cargo.toml** — added `tracing = "0.1"` with `log` feature.
 
 **lib.rs** — replaced `println!` (goes to `/dev/null` on Android) with
 `log::debug!` / `log::error!` calls. The `tracing` crate's `log` feature
@@ -46,31 +52,15 @@ and reconnect diagnostics) to automatically fall through to the `log` crate
 when no tracing subscriber is installed. `android_logger` then forwards
 everything to logcat.
 
-Log level is controlled by the `verbose_logging` flag passed from Dart's
-`ConvexConfig.debugLogging`: verbose = Debug (all messages), normal = Warn
-(only warnings and errors).
-
-### Verbose logging flag
+### Verbose native-logging flag
 
 **lib.rs** — `MobileConvexClient::new()` accepts a `verbose_logging: bool`
-parameter that controls `android_logger` max level.
+parameter that controls `android_logger`'s max level. Off → `Warn` (default
+quiet). On → `Debug` (full Convex SDK chatter).
 
-**lib/src/convex_config.dart** — added a `debugLogging` field on
-`ConvexConfig` (defaults to `false`) so consumers can drive verbose mode
-from `kDebugMode`. The Dart wrapper (`NativeConvexClient`) passes it
-through to the Rust constructor and gates all informational `debugPrint`
-calls behind it. Error-level logs are always printed.
-
-### Cross-transport number normalisation
-
-**lib/src/utils.dart** — added `normalizeJsonNumbers()` helper.
-
-Dart's `jsonDecode` preserves `1` (int) vs `1.0` (double). The web client
-delivers integers for whole numbers, but the Rust FFI client serialises
-all Convex `Float64` values with a decimal point. This mismatch causes
-`as int` casts in consumer DTOs to throw on mobile. The native client now
-post-processes results through `normalizeJsonNumbers` so consumers see
-the same Dart types regardless of transport.
+**lib/src/convex_config.dart** — exposed as `verboseNativeLogs` on
+`ConvexConfig`. Separate from the Dart-side [`ConvexLogger`](lib/src/convex_logger.dart)
+callback (different layers, different audiences).
 
 ### Bump Convex SDK
 
@@ -85,87 +75,102 @@ the same Dart types regardless of transport.
   unsubscribe. Long-lived sessions with many distinct subscriptions (Invyte's
   exact shape: events, chat, live) accumulated ~8 KB per query result. Also
   raises Rust MSRV to 1.85; pulls in `imbl` 7.0 (major bump) and new
-  transitives `safe_arch` + `wide`. Mirrors upstream PR #20.
+  transitives `safe_arch` + `wide`.
 
-## Web client (`lib/src/impl/convex_client_web.dart`)
+## Dart layer (`lib/src/`)
 
-All patches listed in the file header comment (patches 1–9):
+### Structured logging via `ConvexLogger`
 
-### 1. Auth message format
+**lib/src/convex_logger.dart** (new file) — typedef + enum:
 
-`_sendAuthMessage` — corrected `Authenticate` message to use the
-`tokenType`/`value`/`baseVersion` structure expected by the Convex protocol.
+```dart
+typedef ConvexLogger = void Function(ConvexLogLevel level, String source, String message);
+enum ConvexLogLevel { debug, info, warn, error }
+```
 
-### 2. Sign-out sends null token
+Every Dart-side log call routes through `config.logger(level, source, message)`.
+Two ready-made implementations are exported:
 
-`setAuth` — pass `null` instead of `''` for sign-out so `tokenType:"None"` is
-sent to the server.
+- `defaultConvexLogger` — emits `warn`+`error` via `debugPrint`, drops debug/info.
+- `silentConvexLogger` — drops everything.
 
-### 3. Message queueing during connect
+Replaces the old mixed-mode logging (some `debugPrint`s gated behind
+`config.debugLogging`, others always-on as "diagnostic logs"). The consumer
+now decides what to surface by passing a custom callback.
 
-`_sendMessage` — queue messages when the WebSocket is still in `CONNECTING`
-state. Queued messages are flushed automatically once the connection opens.
-Fixes a startup race where operations issued before the handshake completed
-were silently lost.
+### Cross-transport number normalisation
 
-### 4. Void-returning function results
+**lib/src/utils.dart** — added `normalizeJsonNumbers()` helper.
 
-`_handleMutationResponse` / `_handleActionResponse` — check the `success` flag
-before treating a `null` result as an error. Void-returning Convex functions
-legitimately return `null`.
+Dart's `jsonDecode` preserves `1` (int) vs `1.0` (double). The web client
+delivers integers for whole numbers, but the Rust FFI client serialises
+all Convex `Float64` values with a decimal point. Without normalisation,
+`as int` casts in consumer DTOs throw on mobile but succeed on web.
 
-### 5. Structured error types
+Gated by `ConvexConfig.convertWholeNumberDoublesToInts` (default `true`).
+Disable when you need to preserve the int/double distinction semantically.
+No effect on the web transport.
 
-`_handleMutationResponse` / `_handleActionResponse` — emit `ClientError`
-(`convexError` or `serverError` variants) instead of generic `Exception`,
-matching the error types produced by the native FFI client.
+### JWT-aware auth refresh, both transports symmetric
 
-### 6. Separate identity version counter
+`setAuthWithRefresh` signature is now identical on both transports:
 
-`_sendAuthMessage` — use a dedicated `_identityVersion` counter (not
-`_querySetVersion`) for the `Authenticate` message's `baseVersion`. The Convex
-protocol tracks query-set and identity versions independently.
+```dart
+Future<AuthHandle> setAuthWithRefresh({
+  required Future<String?> Function() tokenFetcher,
+  void Function(bool isAuthenticated)? onAuthChange,
+});
+```
 
-### 7. Deliver null subscription values
+- `tokenFetcher` is called immediately for the initial token, then on a
+  schedule driven by the JWT's `exp` claim (~60s before expiry), and again
+  on server-side `AuthError`. The caller is expected to handle their own
+  token caching (e.g. Clerk's `sessionToken()` returns a cached JWT) and
+  to observe individual rotations inside `tokenFetcher` itself.
+- `onAuthChange` fires **only on transitions** (unauthenticated ↔ authenticated)
+  — same contract as the Rust SDK. It does not fire on every scheduled
+  refresh while already authenticated.
 
-`_handleTransition` — forward `null` `QueryUpdated` values to subscribers
-(e.g. a query returning `null` for an unauthenticated user). Previously only
-non-null values were delivered.
+The old `initialToken` parameter is removed — it papered over the web
+client's lack of JWT awareness. The web client now decodes JWT expiry and
+schedules refresh like the Rust SDK does on native (decoder lives in
+`_decodeJwtTtl`), and tracks `wasAuthenticated` to deduplicate
+`onAuthChange` firings.
 
-### 8. Query-set version sync on reconnect
+### Web client (`lib/src/impl/convex_client_web.dart`) — protocol fixes
 
-`onopen` handler — sync `_querySetVersion` after flushing queued
-`ModifyQuerySet` messages so the local counter stays consistent with what the
-server has processed.
+Patches against upstream's pure-Dart web implementation. Most are
+straightforward protocol-correctness fixes:
 
-### 9. Debug logging gating
+**Protocol shape**:
+- `_sendAuthMessage`: correct `Authenticate` format (`tokenType`/`value`/
+  `baseVersion`). Sign-out sends `null` token → `tokenType:"None"`.
+- `_sendAuthMessage`: separate `_identityVersion` counter, distinct from
+  `_querySetVersion`. The Convex protocol tracks these independently.
+- `_handle{Mutation,Action}Response`: check `success` flag before treating
+  `null` result as an error (void-returning functions return `null`
+  legitimately); emit `ClientError` (`convexError` / `serverError`)
+  instead of generic `Exception`, matching native FFI error types.
+- `_handleTransition`: deliver `null` `QueryUpdated` values to subscribers
+  (e.g. a query returning `null` for an unauthenticated user); parse and
+  forward subscription error fields (`errorMessage` / `error_message` /
+  `errorData` / `error`) to `subscription.onError()`.
 
-All informational `debugPrint` calls gated behind `config.debugLogging`.
-Error-level logs are always printed.
+**Connection lifecycle**:
+- `_sendMessage`: queue while WebSocket is `CONNECTING`; flush in `onopen`.
+- `onopen`: sync `_querySetVersion` after flushing queued `ModifyQuerySet`;
+  skip queued `Authenticate` messages (already sent in `onopen`);
+  re-register active subscriptions after reconnect so the new server
+  session knows about them (excluding queryIds already sent via the queue
+  flush to avoid duplicate-Add `InternalServerError`).
+- `_WebSubscription` stores `udfPath + args` for re-registration.
+- `_handleFatalError`: generate a fresh `sessionId` and reset state before
+  reconnect so the server creates a clean session instead of resuming the
+  broken one (which would immediately re-trigger the FatalError).
+- `_sendConnectMessage`: monotonic `_connectionCount` (not
+  `_reconnectAttempts`, which always sent 1).
 
-### 10. Subscription error handling
-
-Added error-field parsing for subscription transition messages. The Convex
-protocol may send `errorMessage`, `error_message`, `errorData`, or `error` keys
-when a subscribed query fails. Previously these were silently ignored (the
-update callback was never called). Now errors are forwarded to
-`subscription.onError()`.
-
-Also added a diagnostic log when a transition message contains neither `value`
-nor an error field.
-
-### 11. `setAuthWithRefresh` — initialToken parameter and auto-refresh
-
-Added `initialToken` optional parameter to `setAuthWithRefresh` across the
-interface, native client, and web client. When provided, the web client uses the
-token directly for the initial `Authenticate` message instead of calling
-`tokenFetcher()`, which would consume the single-use refresh token and cause
-"Invalid refresh token" errors.
-
-Also wired up automatic token refresh on the web client: when the server sends
-an `AuthError` (emitted as `false` on `_authStateController`), the web client
-calls `tokenFetcher()` to obtain a new JWT and re-authenticates. The
-subscription is cancelled when the auth handle is disposed.
-
-The native client accepts the parameter for interface compliance but ignores it
-— the Rust SDK manages the initial fetch and refresh lifecycle internally.
+**Auth + refresh** (covered above): JWT-aware refresh loop, private
+`_authRefreshRequested` stream for server-initiated AuthErrors (decoupled
+from the public `_authStateController` so programmatic state changes
+don't trigger spurious refreshes).

--- a/cargokit/gradle/plugin.gradle
+++ b/cargokit/gradle/plugin.gradle
@@ -134,11 +134,11 @@ class CargoKitPlugin implements Plugin<Project> {
 
             def platforms = com.flutter.gradle.FlutterPluginUtils.getTargetPlatforms(project).collect()
 
-            // Same thing addFlutterDependencies does in flutter.gradle
-            if (buildType == "debug") {
-                platforms.add("android-x86")
-                platforms.add("android-x64")
-            }
+            // VENDORED: upstream force-adds android-x86 + android-x64 here for
+            // debug builds (mirroring flutter.gradle's emulator support). Invyte
+            // only ships arm64-v8a, so compiling those wastes 60-90s of Rust
+            // cross-compile per debug iteration. To re-enable emulator builds,
+            // restore the upstream lines or pass --target-platform=android-x64.
 
             // The task name depends on plugin properties, which are not available
             // at this point

--- a/lib/convex_flutter.dart
+++ b/lib/convex_flutter.dart
@@ -5,5 +5,7 @@ export 'src/rust/frb_generated.dart' show RustLib;
 export 'src/convex_client.dart'
     show ConvexClient, AuthHandleWrapper, TokenFetcher, AuthStateCallback;
 export 'src/convex_config.dart' show ConvexConfig;
+export 'src/convex_logger.dart'
+    show ConvexLogger, ConvexLogLevel, defaultConvexLogger, silentConvexLogger;
 export 'src/connection_status.dart' show ConnectionStatus;
 export 'src/app_lifecycle_event.dart' show AppLifecycleEvent;

--- a/lib/src/convex_client.dart
+++ b/lib/src/convex_client.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 
 import 'package:convex_flutter/src/impl/convex_client_interface.dart';
 import 'package:convex_flutter/src/impl/convex_client_factory.dart';
-import 'package:convex_flutter/src/rust/lib.dart' show WebSocketConnectionState, SubscriptionHandle, AuthHandle;
+import 'package:convex_flutter/src/rust/lib.dart'
+    show WebSocketConnectionState, SubscriptionHandle, AuthHandle;
 import 'package:convex_flutter/src/connection_status.dart';
 import 'package:convex_flutter/src/convex_config.dart';
 import 'package:convex_flutter/src/app_lifecycle_event.dart';
@@ -141,10 +142,7 @@ class ConvexClient {
   }) async {
     if (_instance == null) {
       await initialize(
-        ConvexConfig(
-          deploymentUrl: deploymentUrl,
-          clientId: clientId,
-        ),
+        ConvexConfig(deploymentUrl: deploymentUrl, clientId: clientId),
       );
     }
     return _instance!;
@@ -177,8 +175,7 @@ class ConvexClient {
   Future<String> mutation({
     required String name,
     required Map<String, dynamic> args,
-  }) =>
-      _impl.mutation(name: name, args: args);
+  }) => _impl.mutation(name: name, args: args);
 
   /// Executes a Convex action operation with timeout.
   ///
@@ -190,8 +187,7 @@ class ConvexClient {
   Future<String> action({
     required String name,
     required Map<String, dynamic> args,
-  }) =>
-      _impl.action(name: name, args: args);
+  }) => _impl.action(name: name, args: args);
 
   /// Creates a real-time subscription to a Convex query.
   ///
@@ -206,13 +202,12 @@ class ConvexClient {
     required Map<String, dynamic> args,
     required void Function(String) onUpdate,
     required void Function(String, String?) onError,
-  }) =>
-      _impl.subscribe(
-        name: name,
-        args: args,
-        onUpdate: onUpdate,
-        onError: onError,
-      );
+  }) => _impl.subscribe(
+    name: name,
+    args: args,
+    onUpdate: onUpdate,
+    onError: onError,
+  );
 
   // ============================================================================
   // Authentication API
@@ -260,15 +255,20 @@ class ConvexClient {
   ///
   /// [fetchToken] - Async function that returns a JWT token, or null to sign out.
   /// [onAuthChange] - Optional callback invoked when auth state changes.
+  /// [initialToken] - When provided, the client uses this token for the
+  ///   initial auth instead of calling [fetchToken]. Avoids a redundant
+  ///   token fetch when the caller already holds a valid JWT.
   ///
   /// Returns an [AuthHandleWrapper] that can be used to dispose the auth session.
   Future<AuthHandleWrapper> setAuthWithRefresh({
     required TokenFetcher fetchToken,
     AuthStateCallback? onAuthChange,
+    String? initialToken,
   }) async {
     final handle = await _impl.setAuthWithRefresh(
       tokenFetcher: fetchToken,
       onAuthChange: onAuthChange,
+      initialToken: initialToken,
     );
     return AuthHandleWrapper._(handle);
   }

--- a/lib/src/convex_client.dart
+++ b/lib/src/convex_client.dart
@@ -12,7 +12,11 @@ import 'package:convex_flutter/src/app_lifecycle_event.dart';
 /// Should return a JWT token string, or null to sign out.
 typedef TokenFetcher = Future<String?> Function();
 
-/// Callback type for authentication state changes.
+/// Callback type for authentication state transitions.
+///
+/// Fires when auth goes from unauthenticated to authenticated, or vice
+/// versa. Does NOT fire on every token refresh — observe rotations
+/// inside your own `tokenFetcher`.
 typedef AuthStateCallback = void Function(bool isAuthenticated);
 
 /// A client for interacting with a Convex backend service.
@@ -253,22 +257,23 @@ class ConvexClient {
   /// authHandle.dispose();
   /// ```
   ///
-  /// [fetchToken] - Async function that returns a JWT token, or null to sign out.
-  /// [onAuthChange] - Optional callback invoked when auth state changes.
-  /// [initialToken] - When provided, the client uses this token for the
-  ///   initial auth instead of calling [fetchToken]. Avoids a redundant
-  ///   token fetch when the caller already holds a valid JWT.
+  /// [fetchToken] - Async function that returns a JWT token, or null to sign
+  ///   out. Called immediately for the initial token, then on a schedule
+  ///   driven by the JWT's `exp` claim (~60s before expiry), and again on
+  ///   server-side auth errors. Should be cheap to call repeatedly; the
+  ///   client expects the caller's token store to handle caching.
+  /// [onAuthChange] - Optional callback invoked on auth state **transitions**
+  ///   only (unauthenticated ↔ authenticated). Use [fetchToken] to observe
+  ///   individual rotations.
   ///
   /// Returns an [AuthHandleWrapper] that can be used to dispose the auth session.
   Future<AuthHandleWrapper> setAuthWithRefresh({
     required TokenFetcher fetchToken,
     AuthStateCallback? onAuthChange,
-    String? initialToken,
   }) async {
     final handle = await _impl.setAuthWithRefresh(
       tokenFetcher: fetchToken,
       onAuthChange: onAuthChange,
-      initialToken: initialToken,
     );
     return AuthHandleWrapper._(handle);
   }

--- a/lib/src/convex_config.dart
+++ b/lib/src/convex_config.dart
@@ -43,11 +43,19 @@ class ConvexConfig {
   /// queries and catching TimeoutException.
   final String? healthCheckQuery;
 
+  /// Whether to emit verbose debug logs (connection chatter, pongs, state
+  /// transitions, raw messages, etc.).
+  ///
+  /// Defaults to `false`. Set to `true` (e.g. via `kDebugMode`) to see
+  /// informational logs. Error-level logs are always printed regardless.
+  final bool debugLogging;
+
   /// Creates a new ConvexConfig with the specified options.
   const ConvexConfig({
     required this.deploymentUrl,
     this.clientId,
     this.operationTimeout = const Duration(seconds: 30),
     this.healthCheckQuery,
+    this.debugLogging = false,
   });
 }

--- a/lib/src/convex_config.dart
+++ b/lib/src/convex_config.dart
@@ -1,3 +1,5 @@
+import 'convex_logger.dart';
+
 /// Configuration for ConvexClient initialization.
 ///
 /// This class holds all configuration options for initializing
@@ -43,12 +45,46 @@ class ConvexConfig {
   /// queries and catching TimeoutException.
   final String? healthCheckQuery;
 
-  /// Whether to emit verbose debug logs (connection chatter, pongs, state
-  /// transitions, raw messages, etc.).
+  /// Callback invoked for every diagnostic log emitted by the Dart side
+  /// of the client (native and web).
   ///
-  /// Defaults to `false`. Set to `true` (e.g. via `kDebugMode`) to see
-  /// informational logs. Error-level logs are always printed regardless.
-  final bool debugLogging;
+  /// Receives `(level, source, message)`. Implementations should filter
+  /// by level and route to whatever logging framework the host app uses
+  /// (e.g. `package:logging`, Sentry, stdout).
+  ///
+  /// Defaults to [defaultConvexLogger], which emits `warn` and `error`
+  /// via `debugPrint`. Use [silentConvexLogger] to drop everything, or
+  /// pass a custom callback to integrate with your logger.
+  ///
+  /// Does **not** receive Rust-side logs (those go to logcat on Android
+  /// via `android_logger`; control their volume with [verboseNativeLogs]).
+  final ConvexLogger logger;
+
+  /// Whether the native Rust client emits debug-level logs to logcat
+  /// (Android). When `false` (default), only warnings and errors are
+  /// surfaced. When `true`, all Convex SDK tracing events (reconnect,
+  /// backoff, protocol chatter) are emitted at debug level.
+  ///
+  /// Independent of [logger]: Rust-side logs go through `android_logger`,
+  /// not through the [ConvexLogger] callback.
+  ///
+  /// No effect on the web transport (no Rust runtime there).
+  final bool verboseNativeLogs;
+
+  /// Whether to coerce whole-number doubles (e.g. `42.0`) to ints (`42`)
+  /// in query/mutation/action/subscribe results on the native FFI path.
+  ///
+  /// The native (Rust) transport serialises all Convex `Float64` values
+  /// with a decimal point, while the web transport emits ints for whole
+  /// numbers. Without normalisation, `as int` casts in consumer DTOs
+  /// throw on mobile but succeed on web.
+  ///
+  /// Defaults to `true` (cross-transport symmetry). Set to `false` if you
+  /// need to preserve the distinction between `42` and `42.0` — useful
+  /// when the JSON payload encodes that distinction semantically.
+  ///
+  /// No effect on the web transport.
+  final bool convertWholeNumberDoublesToInts;
 
   /// Creates a new ConvexConfig with the specified options.
   const ConvexConfig({
@@ -56,6 +92,8 @@ class ConvexConfig {
     this.clientId,
     this.operationTimeout = const Duration(seconds: 30),
     this.healthCheckQuery,
-    this.debugLogging = false,
+    this.logger = defaultConvexLogger,
+    this.verboseNativeLogs = false,
+    this.convertWholeNumberDoublesToInts = true,
   });
 }

--- a/lib/src/convex_logger.dart
+++ b/lib/src/convex_logger.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/foundation.dart';
+
+/// Severity of a log event emitted by the Convex client.
+enum ConvexLogLevel { debug, info, warn, error }
+
+/// Callback invoked for every log event the Convex client wants to surface.
+///
+/// - [level] is the severity.
+/// - [source] is a short tag identifying the subsystem (e.g. `"native"`,
+///   `"web"`, `"auth"`, `"ws"`).
+/// - [message] is the human-readable log line.
+///
+/// Implementations should be cheap and non-throwing; the client does not
+/// guard against logger exceptions.
+typedef ConvexLogger =
+    void Function(ConvexLogLevel level, String source, String message);
+
+/// Default logger — emits `warn` and `error` to [debugPrint], drops
+/// `debug` and `info`. Suitable when the consumer hasn't wired up its own
+/// logging framework.
+void defaultConvexLogger(ConvexLogLevel level, String source, String message) {
+  if (level.index < ConvexLogLevel.warn.index) return;
+  debugPrint('[convex_flutter/$source/${level.name}] $message');
+}
+
+/// Silent logger — drops everything. Use when integrating with a logging
+/// framework that handles its own output suppression, or in tests.
+void silentConvexLogger(ConvexLogLevel _, String __, String ___) {}

--- a/lib/src/impl/convex_client_interface.dart
+++ b/lib/src/impl/convex_client_interface.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
-import 'package:convex_flutter/src/rust/lib.dart' show WebSocketConnectionState, SubscriptionHandle, AuthHandle;
+import 'package:convex_flutter/src/rust/lib.dart'
+    show WebSocketConnectionState, SubscriptionHandle, AuthHandle;
 import 'package:convex_flutter/src/connection_status.dart';
 import 'package:convex_flutter/src/convex_config.dart';
 import 'package:convex_flutter/src/app_lifecycle_event.dart';
@@ -91,13 +92,19 @@ abstract class IConvexClient {
 
   /// Sets authentication with automatic token refresh.
   ///
-  /// [tokenFetcher] - Function that returns a fresh JWT token when called
-  /// [onAuthChange] - Optional callback for auth state changes
+  /// [tokenFetcher] - Function that returns a fresh JWT token when called.
+  /// [onAuthChange] - Optional callback for auth state changes.
+  /// [initialToken] - When provided, the client uses this token for the
+  ///   initial `auth:signIn` instead of calling [tokenFetcher]. This avoids
+  ///   a redundant token fetch when the caller already holds a valid JWT
+  ///   (e.g. from `restoreSession`). When `null`, [tokenFetcher] is called
+  ///   immediately to obtain the initial token (existing behaviour).
   ///
   /// Returns an [AuthHandle] that manages the auth session and token refresh.
   Future<AuthHandle> setAuthWithRefresh({
     required Future<String?> Function() tokenFetcher,
     void Function(bool isAuthenticated)? onAuthChange,
+    String? initialToken,
   });
 
   /// Clears the authentication token and stops any active token refresh.

--- a/lib/src/impl/convex_client_interface.dart
+++ b/lib/src/impl/convex_client_interface.dart
@@ -90,21 +90,27 @@ abstract class IConvexClient {
   /// Used to authenticate requests to the Convex backend.
   Future<void> setAuth({required String? token});
 
-  /// Sets authentication with automatic token refresh.
+  /// Sets authentication with automatic, JWT-aware token refresh.
   ///
-  /// [tokenFetcher] - Function that returns a fresh JWT token when called.
-  /// [onAuthChange] - Optional callback for auth state changes.
-  /// [initialToken] - When provided, the client uses this token for the
-  ///   initial `auth:signIn` instead of calling [tokenFetcher]. This avoids
-  ///   a redundant token fetch when the caller already holds a valid JWT
-  ///   (e.g. from `restoreSession`). When `null`, [tokenFetcher] is called
-  ///   immediately to obtain the initial token (existing behaviour).
+  /// [tokenFetcher] is called whenever a token is needed:
+  ///   - immediately, to obtain the initial token,
+  ///   - again, ~60 seconds before the current JWT's `exp` claim,
+  ///   - and again on `AuthError` from the server.
   ///
-  /// Returns an [AuthHandle] that manages the auth session and token refresh.
+  /// The caller's [tokenFetcher] is expected to be idempotent / cache-friendly
+  /// (e.g. Clerk's `sessionToken()` returns a cached JWT until it expires) —
+  /// the client may call it more than once in quick succession with no
+  /// special "initial vs refresh" distinction. If you need to observe each
+  /// individual token rotation, do it inside [tokenFetcher].
+  ///
+  /// [onAuthChange] fires on auth state **transitions** only (unauthenticated
+  /// → authenticated, and vice versa) — not on every refresh.
+  ///
+  /// Returns an [AuthHandle] that owns the refresh timer; call `dispose()`
+  /// to stop refreshes and clear auth.
   Future<AuthHandle> setAuthWithRefresh({
     required Future<String?> Function() tokenFetcher,
     void Function(bool isAuthenticated)? onAuthChange,
-    String? initialToken,
   });
 
   /// Clears the authentication token and stops any active token refresh.

--- a/lib/src/impl/convex_client_native.dart
+++ b/lib/src/impl/convex_client_native.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:convex_flutter/src/impl/convex_client_interface.dart';
 import 'package:convex_flutter/src/rust/lib.dart';
 import 'package:convex_flutter/src/rust/frb_generated.dart';
 import 'package:convex_flutter/src/utils.dart';
 import 'package:convex_flutter/src/connection_status.dart';
 import 'package:convex_flutter/src/convex_config.dart';
+import 'package:convex_flutter/src/convex_logger.dart';
 import 'package:convex_flutter/src/app_lifecycle_event.dart';
 import 'package:convex_flutter/src/app_lifecycle_observer.dart';
 
@@ -64,7 +64,7 @@ class NativeConvexClient implements IConvexClient {
     final rustClient = MobileConvexClient(
       deploymentUrl: config.deploymentUrl,
       clientId: config.clientId ?? 'flutter-client',
-      verboseLogging: config.debugLogging,
+      verboseLogging: config.verboseNativeLogs,
     );
 
     // Create native client wrapper
@@ -88,26 +88,30 @@ class NativeConvexClient implements IConvexClient {
   ///
   /// This must be called before any queries/mutations to capture all state changes.
   Future<void> _setupConnectionStateListener() async {
-    if (config.debugLogging) {
-      debugPrint(
-        '=== [NativeConvexClient] Setting up WebSocket state listener ===',
-      );
-    }
+    config.logger(
+      ConvexLogLevel.debug,
+      'native',
+      'Setting up WebSocket state listener',
+    );
 
     try {
       await _rustClient.onWebsocketStateChange(
         onStateChange: (state) async {
-          if (config.debugLogging) {
-            debugPrint(
-              '=== [NativeConvexClient] State changed: ${state.name} ===',
-            );
-          }
+          config.logger(
+            ConvexLogLevel.debug,
+            'native',
+            'WS state changed: ${state.name}',
+          );
           _currentConnectionState = state;
           _connectionStateController.add(state);
         },
       );
     } catch (e) {
-      debugPrint('ERROR: [NativeConvexClient] Listener setup failed: $e');
+      config.logger(
+        ConvexLogLevel.error,
+        'native',
+        'WS state listener setup failed: $e',
+      );
       rethrow;
     }
   }
@@ -116,13 +120,19 @@ class NativeConvexClient implements IConvexClient {
   // IConvexClient Implementation - Core Operations
   // ============================================================================
 
+  /// Optionally normalises whole-number doubles to ints in result JSON.
+  /// No-op when `config.convertWholeNumberDoublesToInts` is false.
+  String _normalize(String json) => config.convertWholeNumberDoublesToInts
+      ? normalizeJsonNumbers(json)
+      : json;
+
   @override
   Future<String> query(String name, Map<String, dynamic> args) async {
     final formattedArgs = buildArgs(args);
     final result = await _rustClient
         .query(name: name, args: formattedArgs)
         .timeout(config.operationTimeout);
-    return normalizeJsonNumbers(result);
+    return _normalize(result);
   }
 
   @override
@@ -134,7 +144,7 @@ class NativeConvexClient implements IConvexClient {
     final result = await _rustClient
         .mutation(name: name, args: formattedArgs)
         .timeout(config.operationTimeout);
-    return normalizeJsonNumbers(result);
+    return _normalize(result);
   }
 
   @override
@@ -146,7 +156,7 @@ class NativeConvexClient implements IConvexClient {
     final result = await _rustClient
         .action(name: name, args: formattedArgs)
         .timeout(config.operationTimeout);
-    return normalizeJsonNumbers(result);
+    return _normalize(result);
   }
 
   @override
@@ -162,11 +172,12 @@ class NativeConvexClient implements IConvexClient {
       args: formattedArgs,
       onUpdate: (value) {
         try {
-          onUpdate(normalizeJsonNumbers(value));
+          onUpdate(_normalize(value));
         } catch (e, st) {
-          debugPrint(
-            'ERROR: [NativeConvexClient] onUpdate callback threw for '
-            '"$name": $e\n$st',
+          config.logger(
+            ConvexLogLevel.error,
+            'native',
+            'onUpdate callback threw for "$name": $e\n$st',
           );
         }
       },
@@ -174,9 +185,10 @@ class NativeConvexClient implements IConvexClient {
         try {
           onError(message, value);
         } catch (e, st) {
-          debugPrint(
-            'ERROR: [NativeConvexClient] onError callback threw for '
-            '"$name": $e\n$st',
+          config.logger(
+            ConvexLogLevel.error,
+            'native',
+            'onError callback threw for "$name": $e\n$st',
           );
         }
       },
@@ -201,14 +213,12 @@ class NativeConvexClient implements IConvexClient {
   Future<AuthHandle> setAuthWithRefresh({
     required Future<String?> Function() tokenFetcher,
     void Function(bool isAuthenticated)? onAuthChange,
-    String? initialToken,
   }) async {
     // Dispose any existing auth handle
     _currentAuthHandle?.dispose();
 
-    // Native: Rust SDK handles initial token fetch and refresh lifecycle.
-    // initialToken is not used — the Rust client always calls tokenFetcher
-    // for the initial auth and manages refresh internally.
+    // The Rust SDK manages the JWT-aware refresh loop and only fires
+    // on_auth_change on transitions — which matches our public contract.
     final handle = await _rustClient.setAuthWithRefresh(
       fetchToken: () async => await tokenFetcher(),
       onAuthChange: (bool isAuth) async {

--- a/lib/src/impl/convex_client_native.dart
+++ b/lib/src/impl/convex_client_native.dart
@@ -64,6 +64,7 @@ class NativeConvexClient implements IConvexClient {
     final rustClient = MobileConvexClient(
       deploymentUrl: config.deploymentUrl,
       clientId: config.clientId ?? 'flutter-client',
+      verboseLogging: config.debugLogging,
     );
 
     // Create native client wrapper
@@ -87,19 +88,24 @@ class NativeConvexClient implements IConvexClient {
   ///
   /// This must be called before any queries/mutations to capture all state changes.
   Future<void> _setupConnectionStateListener() async {
-    debugPrint('=== [NativeConvexClient] Setting up WebSocket state listener ===');
-    debugPrint('=== [NativeConvexClient] Current state: ${_currentConnectionState.name} ===');
+    if (config.debugLogging) {
+      debugPrint(
+        '=== [NativeConvexClient] Setting up WebSocket state listener ===',
+      );
+    }
 
     try {
       await _rustClient.onWebsocketStateChange(
         onStateChange: (state) async {
-          debugPrint('=== [NativeConvexClient] State changed: ${state.name} ===');
+          if (config.debugLogging) {
+            debugPrint(
+              '=== [NativeConvexClient] State changed: ${state.name} ===',
+            );
+          }
           _currentConnectionState = state;
           _connectionStateController.add(state);
-          debugPrint('=== [NativeConvexClient] Stream emission complete ===');
         },
       );
-      debugPrint('=== [NativeConvexClient] Listener registered successfully ===');
     } catch (e) {
       debugPrint('ERROR: [NativeConvexClient] Listener setup failed: $e');
       rethrow;
@@ -113,9 +119,10 @@ class NativeConvexClient implements IConvexClient {
   @override
   Future<String> query(String name, Map<String, dynamic> args) async {
     final formattedArgs = buildArgs(args);
-    return await _rustClient
+    final result = await _rustClient
         .query(name: name, args: formattedArgs)
         .timeout(config.operationTimeout);
+    return normalizeJsonNumbers(result);
   }
 
   @override
@@ -124,9 +131,10 @@ class NativeConvexClient implements IConvexClient {
     required Map<String, dynamic> args,
   }) async {
     final formattedArgs = buildArgs(args);
-    return await _rustClient
+    final result = await _rustClient
         .mutation(name: name, args: formattedArgs)
         .timeout(config.operationTimeout);
+    return normalizeJsonNumbers(result);
   }
 
   @override
@@ -135,9 +143,10 @@ class NativeConvexClient implements IConvexClient {
     required Map<String, dynamic> args,
   }) async {
     final formattedArgs = buildArgs(args);
-    return await _rustClient
+    final result = await _rustClient
         .action(name: name, args: formattedArgs)
         .timeout(config.operationTimeout);
+    return normalizeJsonNumbers(result);
   }
 
   @override
@@ -151,8 +160,26 @@ class NativeConvexClient implements IConvexClient {
     return await _rustClient.subscribe(
       name: name,
       args: formattedArgs,
-      onUpdate: (value) => onUpdate(value),
-      onError: (message, value) => onError(message, value),
+      onUpdate: (value) {
+        try {
+          onUpdate(normalizeJsonNumbers(value));
+        } catch (e, st) {
+          debugPrint(
+            'ERROR: [NativeConvexClient] onUpdate callback threw for '
+            '"$name": $e\n$st',
+          );
+        }
+      },
+      onError: (message, value) {
+        try {
+          onError(message, value);
+        } catch (e, st) {
+          debugPrint(
+            'ERROR: [NativeConvexClient] onError callback threw for '
+            '"$name": $e\n$st',
+          );
+        }
+      },
     );
   }
 
@@ -174,10 +201,14 @@ class NativeConvexClient implements IConvexClient {
   Future<AuthHandle> setAuthWithRefresh({
     required Future<String?> Function() tokenFetcher,
     void Function(bool isAuthenticated)? onAuthChange,
+    String? initialToken,
   }) async {
     // Dispose any existing auth handle
     _currentAuthHandle?.dispose();
 
+    // Native: Rust SDK handles initial token fetch and refresh lifecycle.
+    // initialToken is not used — the Rust client always calls tokenFetcher
+    // for the initial auth and manages refresh internally.
     final handle = await _rustClient.setAuthWithRefresh(
       fetchToken: () async => await tokenFetcher(),
       onAuthChange: (bool isAuth) async {
@@ -213,7 +244,8 @@ class NativeConvexClient implements IConvexClient {
       _connectionStateController.stream;
 
   @override
-  WebSocketConnectionState get currentConnectionState => _currentConnectionState;
+  WebSocketConnectionState get currentConnectionState =>
+      _currentConnectionState;
 
   @override
   bool get isConnected =>

--- a/lib/src/impl/convex_client_web.dart
+++ b/lib/src/impl/convex_client_web.dart
@@ -1,43 +1,45 @@
-// VENDORED & PATCHED — do not replace from pub.dev without re-applying fixes.
-// Patches applied on top of convex_flutter 3.0.1:
-//   1. _sendAuthMessage: correct Authenticate message format (tokenType/value/baseVersion)
-//   2. setAuth: pass null instead of '' for sign-out so tokenType:"None" is sent
-//   3. _sendMessage: queue messages when WebSocket is still CONNECTING (fixes startup race)
-//   4. _handleMutationResponse / _handleActionResponse: check success flag before
-//      treating null result as an error (void-returning functions return null legitimately)
-//   5. _handleMutationResponse / _handleActionResponse: emit ClientError (convexError
-//      or serverError) instead of generic Exception, matching native FFI error types
-//   6. _sendAuthMessage: use separate _identityVersion counter (not _querySetVersion)
-//      for Authenticate baseVersion — the Convex protocol tracks these independently
-//   7. _handleTransition: deliver null QueryUpdated values to subscribers (e.g. query
-//      returning null for unauthenticated user)
-//   8. onopen: sync _querySetVersion after flushing queued ModifyQuerySet messages
-//   9. All informational debugPrint calls gated behind config.debugLogging
-//  10. onopen: skip queued Authenticate messages during flush (onopen already sends
-//      auth from _currentAuthToken — flushing a duplicate causes a protocol error)
-//  11. onopen: re-register active subscriptions after reconnect so the new server
-//      session knows about them (previously subscriptions were lost on WS drop);
-//      excludes queryIds already sent via queue flush to avoid duplicate Add errors
-//  12. _handleFatalError: generate fresh sessionId and reset state before reconnect
-//      so the server creates a clean session instead of resuming stale state
-//  13. _sendConnectMessage: use _connectionCount (monotonic) instead of
-//      _reconnectAttempts for connectionCount field — the old code always sent 1
-//  14. _WebSubscription: store udfPath + args for re-registration on reconnect
-//  15. Always-on diagnostic logging for WS open/close, setAuth, AuthError,
-//      FatalError, and max-reconnect — not gated behind debugLogging
+// Invyte fork — divergent from upstream convex_flutter. See VENDOR_CHANGES.md
+// for the catalogue of patches. Highlights, by area:
+//
+// Protocol correctness:
+//   - _sendAuthMessage: correct Authenticate format (tokenType/value/baseVersion)
+//   - setAuth: pass null (not '') on sign-out so tokenType:"None" is sent
+//   - _handleMutationResponse / _handleActionResponse: check success flag before
+//     treating null result as error (void-returning functions return null)
+//   - _handleMutationResponse / _handleActionResponse: emit ClientError
+//     (convexError / serverError) — matches native FFI error types
+//   - _sendAuthMessage: separate _identityVersion counter (not _querySetVersion)
+//   - _handleTransition: deliver null QueryUpdated values to subscribers
+//   - _handleTransition: parse and forward subscription errors (errorMessage /
+//     error_message / errorData / error)
+//
+// Connection lifecycle:
+//   - _sendMessage: queue while CONNECTING, flush on open
+//   - onopen: sync _querySetVersion after flushing queued ModifyQuerySet
+//   - onopen: skip queued Authenticate (already sent in onopen handler)
+//   - onopen: re-register active subscriptions after reconnect (excluding
+//     queryIds already in the flushed queue)
+//   - _handleFatalError: generate fresh sessionId + reset state before reconnect
+//   - _sendConnectMessage: use monotonic _connectionCount (not _reconnectAttempts)
+//   - _WebSubscription stores udfPath + args for re-registration on reconnect
+//
+// Auth + observability:
+//   - setAuthWithRefresh: JWT-aware refresh loop (decode exp, schedule refresh
+//     ~60s before expiry); onAuthChange receives the current token
+//   - All logs go through config.logger (ConvexLogger callback) — no debugPrint
 
 import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart';
 import 'package:web/web.dart' as web;
 import 'package:convex_flutter/src/impl/convex_client_interface.dart';
 import 'package:convex_flutter/src/rust/lib.dart'
     show AuthHandle, ClientError, SubscriptionHandle, WebSocketConnectionState;
 import 'package:convex_flutter/src/connection_status.dart';
 import 'package:convex_flutter/src/convex_config.dart';
+import 'package:convex_flutter/src/convex_logger.dart';
 import 'package:convex_flutter/src/app_lifecycle_event.dart';
 import 'package:convex_flutter/src/app_lifecycle_observer.dart';
 
@@ -57,9 +59,16 @@ class WebConvexClient implements IConvexClient {
   /// WebSocket connection to Convex backend
   web.WebSocket? _ws;
 
-  /// Stream controller for auth state changes
+  /// Stream controller for auth state changes (public via [authState]).
   final StreamController<bool> _authStateController =
       StreamController<bool>.broadcast();
+
+  /// Private signal — server-side AuthError received. The refresh loop in
+  /// [setAuthWithRefresh] listens here so it can react to server-initiated
+  /// auth failures without being confused by programmatic state changes
+  /// emitted on [_authStateController].
+  final StreamController<void> _authRefreshRequested =
+      StreamController<void>.broadcast();
 
   /// Stream controller for lifecycle events
   final StreamController<AppLifecycleEvent> _lifecycleController =
@@ -133,8 +142,7 @@ class WebConvexClient implements IConvexClient {
   /// - Event listener registration
   /// - Lifecycle observer setup
   static Future<WebConvexClient> create(ConvexConfig config) async {
-    if (config.debugLogging)
-      debugPrint('=== [WebConvexClient] Creating web client ===');
+    config.logger(ConvexLogLevel.debug, 'web', 'Creating web client');
 
     final client = WebConvexClient._(config);
 
@@ -147,18 +155,18 @@ class WebConvexClient implements IConvexClient {
       onLifecycleChange: (event) {
         client._lifecycleController.add(event);
         // Do NOT trigger reconnection on web - let WebSocket manage itself
-        if (config.debugLogging)
-          debugPrint(
-            '=== [WebConvexClient] Lifecycle event: ${event.name} (no action on web) ===',
-          );
+        config.logger(
+          ConvexLogLevel.debug,
+          'web',
+          'Lifecycle event: ${event.name} (no action on web)',
+        );
       },
     );
 
     // Establish WebSocket connection
     await client._connect();
 
-    if (config.debugLogging)
-      debugPrint('=== [WebConvexClient] Client created successfully ===');
+    config.logger(ConvexLogLevel.debug, 'web', 'Client created successfully');
     return client;
   }
 
@@ -166,8 +174,7 @@ class WebConvexClient implements IConvexClient {
   Future<void> _connect() async {
     if (_isDisposed) return;
 
-    if (config.debugLogging)
-      debugPrint('=== [WebConvexClient] Connecting to Convex ===');
+    config.logger(ConvexLogLevel.debug, 'web', 'Connecting to Convex');
 
     try {
       // Convert HTTPS to WSS URL with correct Convex sync endpoint
@@ -175,8 +182,7 @@ class WebConvexClient implements IConvexClient {
       final wsUrl = config.deploymentUrl.replaceFirst('https', 'wss');
       final fullUrl = '$wsUrl/api/sync';
 
-      if (config.debugLogging)
-        debugPrint('=== [WebConvexClient] WebSocket URL: $fullUrl ===');
+      config.logger(ConvexLogLevel.debug, 'web', 'WebSocket URL: $fullUrl');
 
       // Update state to connecting
       _updateConnectionState(WebSocketConnectionState.connecting);
@@ -187,10 +193,13 @@ class WebConvexClient implements IConvexClient {
       // Setup event listeners
       _setupWebSocketListeners();
 
-      if (config.debugLogging)
-        debugPrint('=== [WebConvexClient] WebSocket connection initiated ===');
+      config.logger(
+        ConvexLogLevel.debug,
+        'web',
+        'WebSocket connection initiated',
+      );
     } catch (e) {
-      debugPrint('ERROR: [WebConvexClient] Connection failed: $e');
+      config.logger(ConvexLogLevel.error, 'web', 'Connection failed: $e');
       _scheduleReconnect();
     }
   }
@@ -202,15 +211,11 @@ class WebConvexClient implements IConvexClient {
 
     // Connection opened
     ws.onopen = (web.Event event) {
-      if (config.debugLogging)
-        debugPrint('=== [WebConvexClient] WebSocket opened ===');
-      debugPrint(
-        '[WebConvexClient] WS connected '
-        '(session=$_sessionId, connCount=$_connectionCount, '
-        'qsVersion=$_querySetVersion→0, idVersion=$_identityVersion→0, '
-        'queueLen=${_messageQueue.length}, '
-        'activeSubs=${_subscriptions.length}, '
-        'hasAuth=${_currentAuthToken != null})',
+      config.logger(ConvexLogLevel.debug, 'web', 'WebSocket opened');
+      config.logger(
+        ConvexLogLevel.info,
+        'web',
+        'WS connected (session=$_sessionId, connCount=$_connectionCount, qsVersion=$_querySetVersion→0, idVersion=$_identityVersion→0, queueLen=${_messageQueue.length}, activeSubs=${_subscriptions.length}, hasAuth=${_currentAuthToken != null})',
       );
       _reconnectAttempts = 0; // Reset reconnection counter
       _querySetVersion = 0; // Reset query set version for new connection
@@ -233,18 +238,20 @@ class WebConvexClient implements IConvexClient {
       // doesn't duplicate them (duplicate Add → server InternalServerError).
       final flushedQueryIds = <int>{};
       if (_messageQueue.isNotEmpty) {
-        if (config.debugLogging)
-          debugPrint(
-            '=== [WebConvexClient] Flushing ${_messageQueue.length} queued message(s) ===',
-          );
+        config.logger(
+          ConvexLogLevel.debug,
+          'web',
+          'Flushing ${_messageQueue.length} queued message(s)',
+        );
         final queued = List<Map<String, dynamic>>.from(_messageQueue);
         _messageQueue.clear();
         for (final msg in queued) {
           if (msg['type'] == 'Authenticate') {
-            if (config.debugLogging)
-              debugPrint(
-                '=== [WebConvexClient] Skipping queued Authenticate (already sent in onopen) ===',
-              );
+            config.logger(
+              ConvexLogLevel.debug,
+              'web',
+              'Skipping queued Authenticate (already sent in onopen)',
+            );
             continue;
           }
           // Track version changes from queued ModifyQuerySet messages so
@@ -281,11 +288,10 @@ class WebConvexClient implements IConvexClient {
       final code = event.code;
       final reason = event.reason;
       final wasClean = event.wasClean;
-      debugPrint(
-        '[WebConvexClient] WS closed '
-        '(code=$code, reason="$reason", wasClean=$wasClean, '
-        'session=$_sessionId, qsVersion=$_querySetVersion, '
-        'activeSubs=${_subscriptions.length})',
+      config.logger(
+        ConvexLogLevel.info,
+        'web',
+        'WS closed (code=$code, reason="$reason", wasClean=$wasClean, session=$_sessionId, qsVersion=$_querySetVersion, activeSubs=${_subscriptions.length})',
       );
       _updateConnectionState(WebSocketConnectionState.connecting);
 
@@ -297,8 +303,8 @@ class WebConvexClient implements IConvexClient {
 
     // Connection error
     ws.onerror = (web.Event event) {
-      debugPrint('ERROR: [WebConvexClient] WebSocket error occurred');
-      debugPrint('ERROR: [WebConvexClient] Event type: ${event.type}');
+      config.logger(ConvexLogLevel.error, 'web', 'WebSocket error occurred');
+      config.logger(ConvexLogLevel.error, 'web', 'Event type: ${event.type}');
       _updateConnectionState(WebSocketConnectionState.connecting);
     }.toJS;
 
@@ -311,7 +317,11 @@ class WebConvexClient implements IConvexClient {
       if (dataString != null) {
         _handleMessage(dataString);
       } else {
-        debugPrint('WARNING: [WebConvexClient] Received non-string message');
+        config.logger(
+          ConvexLogLevel.warn,
+          'web',
+          'Received non-string message',
+        );
       }
     }.toJS;
   }
@@ -319,17 +329,17 @@ class WebConvexClient implements IConvexClient {
   /// Handles incoming WebSocket messages.
   void _handleMessage(String data) {
     try {
-      if (config.debugLogging)
-        debugPrint('=== [WebConvexClient] RAW MESSAGE: $data ===');
+      config.logger(ConvexLogLevel.debug, 'web', 'RAW MESSAGE: $data');
 
       final message = jsonDecode(data) as Map<String, dynamic>;
       final type = message['type'] as String?;
       final id = message['id'] as String?;
 
-      if (config.debugLogging)
-        debugPrint(
-          '=== [WebConvexClient] Received message type: $type, id: $id ===',
-        );
+      config.logger(
+        ConvexLogLevel.debug,
+        'web',
+        'Received message type: $type, id: $id',
+      );
 
       switch (type) {
         case 'Transition':
@@ -359,10 +369,14 @@ class WebConvexClient implements IConvexClient {
           break;
 
         default:
-          debugPrint('WARNING: [WebConvexClient] Unknown message type: $type');
+          config.logger(
+            ConvexLogLevel.warn,
+            'web',
+            'Unknown message type: $type',
+          );
       }
     } catch (e) {
-      debugPrint('ERROR: [WebConvexClient] Failed to parse message: $e');
+      config.logger(ConvexLogLevel.error, 'web', 'Failed to parse message: $e');
     }
   }
 
@@ -390,9 +404,10 @@ class WebConvexClient implements IConvexClient {
           (mod['error'] is Map ? jsonEncode(mod['error']) : null);
 
       if (errorMessage != null) {
-        debugPrint(
-          '=== [WebConvexClient] Subscription error for queryId=$queryId: '
-          '$errorMessage (data: $errorData) ===',
+        config.logger(
+          ConvexLogLevel.warn,
+          'web',
+          'Subscription error for queryId=$queryId: $errorMessage (data: $errorData)',
         );
         subscription.onError(errorMessage, errorData);
         continue;
@@ -401,9 +416,10 @@ class WebConvexClient implements IConvexClient {
       // If there's no value key at all AND no error, log for diagnostics
       // (this shouldn't happen in normal protocol flow).
       if (!mod.containsKey('value')) {
-        debugPrint(
-          '=== [WebConvexClient] Transition mod with no value or error for '
-          'queryId=$queryId. Keys: ${(mod as Map).keys.toList()} ===',
+        config.logger(
+          ConvexLogLevel.warn,
+          'web',
+          'Transition mod with no value or error for queryId=$queryId. Keys: ${(mod as Map).keys.toList()}',
         );
         continue;
       }
@@ -468,10 +484,10 @@ class WebConvexClient implements IConvexClient {
   /// Handles FatalError messages.
   void _handleFatalError(Map<String, dynamic> message) {
     final error = message['error'] as String? ?? 'Unknown fatal error';
-    debugPrint(
-      'FATAL ERROR: [WebConvexClient] $error '
-      '(session=$_sessionId, qsVersion=$_querySetVersion, '
-      'idVersion=$_identityVersion, activeSubs=${_subscriptions.length})',
+    config.logger(
+      ConvexLogLevel.error,
+      'web',
+      '$error (session=$_sessionId, qsVersion=$_querySetVersion, idVersion=$_identityVersion, activeSubs=${_subscriptions.length})',
     );
 
     // Force a brand-new server session on the next reconnect by discarding
@@ -491,14 +507,16 @@ class WebConvexClient implements IConvexClient {
   void _handleAuthError(Map<String, dynamic> message) {
     final error = message['error'] as String? ?? 'Authentication error';
     final code = message['errorCode'] as String?;
-    debugPrint(
-      'AUTH ERROR: [WebConvexClient] $error '
-      '(code=$code, hasToken=${_currentAuthToken != null}, '
-      'session=$_sessionId)',
+    config.logger(
+      ConvexLogLevel.error,
+      'web',
+      'AuthError: $error (code=$code, hasToken=${_currentAuthToken != null}, session=$_sessionId)',
     );
 
-    // Clear auth and notify — triggers token refresh via setAuthWithRefresh
+    // Public state stream: notify consumers that we lost auth.
     _authStateController.add(false);
+    // Private signal: kick the refresh loop in setAuthWithRefresh.
+    if (!_authRefreshRequested.isClosed) _authRefreshRequested.add(null);
   }
 
   /// Sends Pong response to server Ping.
@@ -509,10 +527,9 @@ class WebConvexClient implements IConvexClient {
         'eventType': 'Pong', // Required field
         'event': null, // Required field (can be null)
       });
-      if (config.debugLogging)
-        debugPrint('=== [WebConvexClient] Sent Pong ===');
+      config.logger(ConvexLogLevel.debug, 'web', 'Sent Pong');
     } catch (e) {
-      debugPrint('ERROR: [WebConvexClient] Failed to send Pong: $e');
+      config.logger(ConvexLogLevel.error, 'web', 'Failed to send Pong: $e');
     }
   }
 
@@ -532,12 +549,13 @@ class WebConvexClient implements IConvexClient {
         'lastCloseReason': null, // Required field
         'clientTs': DateTime.now().millisecondsSinceEpoch, // Required field
       });
-      if (config.debugLogging)
-        debugPrint(
-          '=== [WebConvexClient] Sent Connect handshake (session=$_sessionId, count=${_connectionCount - 1}) ===',
-        );
+      config.logger(
+        ConvexLogLevel.debug,
+        'web',
+        'Sent Connect handshake (session=$_sessionId, count=${_connectionCount - 1})',
+      );
     } catch (e) {
-      debugPrint('ERROR: [WebConvexClient] Failed to send Connect: $e');
+      config.logger(ConvexLogLevel.error, 'web', 'Failed to send Connect: $e');
     }
   }
 
@@ -579,10 +597,11 @@ class WebConvexClient implements IConvexClient {
   /// Updates connection state and emits to stream.
   void _updateConnectionState(WebSocketConnectionState newState) {
     if (_currentConnectionState != newState) {
-      if (config.debugLogging)
-        debugPrint(
-          '=== [WebConvexClient] State transition: ${_currentConnectionState.name} → ${newState.name} ===',
-        );
+      config.logger(
+        ConvexLogLevel.debug,
+        'web',
+        'State transition: ${_currentConnectionState.name} → ${newState.name}',
+      );
       _currentConnectionState = newState;
       _connectionStateController.add(newState);
     }
@@ -595,10 +614,10 @@ class WebConvexClient implements IConvexClient {
     _reconnectTimer?.cancel();
 
     if (_reconnectAttempts >= _maxReconnectAttempts) {
-      debugPrint(
-        'ERROR: [WebConvexClient] Max reconnection attempts reached '
-        '(activeSubs=${_subscriptions.length}, '
-        'pendingRequests=${_pendingRequests.length})',
+      config.logger(
+        ConvexLogLevel.error,
+        'web',
+        'Max reconnection attempts reached (activeSubs=${_subscriptions.length}, pendingRequests=${_pendingRequests.length})',
       );
       return;
     }
@@ -607,16 +626,18 @@ class WebConvexClient implements IConvexClient {
     final delay = _baseReconnectDelay * (1 << _reconnectAttempts.clamp(0, 5));
     _reconnectAttempts++;
 
-    if (config.debugLogging)
-      debugPrint(
-        '=== [WebConvexClient] Scheduling reconnect attempt $_reconnectAttempts in ${delay.inSeconds}s ===',
-      );
+    config.logger(
+      ConvexLogLevel.debug,
+      'web',
+      'Scheduling reconnect attempt $_reconnectAttempts in ${delay.inSeconds}s',
+    );
 
     _reconnectTimer = Timer(delay, () {
-      if (config.debugLogging)
-        debugPrint(
-          '=== [WebConvexClient] Executing reconnect attempt $_reconnectAttempts ===',
-        );
+      config.logger(
+        ConvexLogLevel.debug,
+        'web',
+        'Executing reconnect attempt $_reconnectAttempts',
+      );
       _connect();
     });
   }
@@ -633,22 +654,23 @@ class WebConvexClient implements IConvexClient {
     final ws = _ws;
     if (ws == null || ws.readyState != web.WebSocket.OPEN) {
       _messageQueue.add(message);
-      if (config.debugLogging)
-        debugPrint(
-          '=== [WebConvexClient] Queued message (WS not ready): ${message['type']} ===',
-        );
+      config.logger(
+        ConvexLogLevel.debug,
+        'web',
+        'Queued message (WS not ready): ${message['type']}',
+      );
       return;
     }
 
     final messageJson = jsonEncode(message);
-    if (config.debugLogging)
-      debugPrint('=== [WebConvexClient] SENDING: $messageJson ===');
+    config.logger(ConvexLogLevel.debug, 'web', 'SENDING: $messageJson');
     ws.send(messageJson.toJS);
 
-    if (config.debugLogging)
-      debugPrint(
-        '=== [WebConvexClient] Sent message: ${message['type']} (id: ${message['id']}) ===',
-      );
+    config.logger(
+      ConvexLogLevel.debug,
+      'web',
+      'Sent message: ${message['type']} (id: ${message['id']})',
+    );
   }
 
   /// Sends authentication message.
@@ -676,10 +698,9 @@ class WebConvexClient implements IConvexClient {
           'baseVersion': baseVersion,
         });
       }
-      if (config.debugLogging)
-        debugPrint('=== [WebConvexClient] Auth token sent ===');
+      config.logger(ConvexLogLevel.debug, 'web', 'Auth token sent');
     } catch (e) {
-      debugPrint('ERROR: [WebConvexClient] Failed to send auth: $e');
+      config.logger(ConvexLogLevel.error, 'web', 'Failed to send auth: $e');
     }
   }
 
@@ -851,10 +872,11 @@ class WebConvexClient implements IConvexClient {
         ],
       });
 
-      if (config.debugLogging)
-        debugPrint(
-          '=== [WebConvexClient] Subscription created: queryId=$queryId ===',
-        );
+      config.logger(
+        ConvexLogLevel.debug,
+        'web',
+        'Subscription created: queryId=$queryId',
+      );
 
       // Return handle for cancellation
       return _WebSubscriptionHandle(
@@ -873,10 +895,11 @@ class WebConvexClient implements IConvexClient {
     final subscription = _subscriptions.remove(queryIdStr);
     if (subscription == null) return;
 
-    if (config.debugLogging)
-      debugPrint(
-        '=== [WebConvexClient] Unsubscribing: queryId=$queryIdStr ===',
-      );
+    config.logger(
+      ConvexLogLevel.debug,
+      'web',
+      'Unsubscribing: queryId=$queryIdStr',
+    );
 
     try {
       final queryId = int.tryParse(queryIdStr);
@@ -895,7 +918,11 @@ class WebConvexClient implements IConvexClient {
         ],
       });
     } catch (e) {
-      debugPrint('ERROR: [WebConvexClient] Failed to send unsubscribe: $e');
+      config.logger(
+        ConvexLogLevel.error,
+        'web',
+        'Failed to send unsubscribe: $e',
+      );
     }
   }
 
@@ -910,22 +937,22 @@ class WebConvexClient implements IConvexClient {
     // Collect subscriptions that can be re-registered (have stored query info
     // and are long-lived subscriptions, not one-shot queries).
     // Skip any queryIds that were already sent during queue flush.
-    final resubs =
-        _subscriptions.values
-            .where(
-              (s) =>
-                  s.isSubscription &&
-                  s.udfPath != null &&
-                  !excludeQueryIds.contains(int.tryParse(s.id)),
-            )
-            .toList();
+    final resubs = _subscriptions.values
+        .where(
+          (s) =>
+              s.isSubscription &&
+              s.udfPath != null &&
+              !excludeQueryIds.contains(int.tryParse(s.id)),
+        )
+        .toList();
 
     if (resubs.isEmpty) return;
 
-    if (config.debugLogging)
-      debugPrint(
-        '=== [WebConvexClient] Re-registering ${resubs.length} subscription(s) after reconnect ===',
-      );
+    config.logger(
+      ConvexLogLevel.debug,
+      'web',
+      'Re-registering ${resubs.length} subscription(s) after reconnect',
+    );
 
     final modifications = <Map<String, dynamic>>[];
     for (final sub in resubs) {
@@ -952,10 +979,11 @@ class WebConvexClient implements IConvexClient {
       'modifications': modifications,
     });
 
-    if (config.debugLogging)
-      debugPrint(
-        '=== [WebConvexClient] Re-registered ${modifications.length} subscription(s) (version $baseVersion → $newVersion) ===',
-      );
+    config.logger(
+      ConvexLogLevel.debug,
+      'web',
+      'Re-registered ${modifications.length} subscription(s) (version $baseVersion → $newVersion)',
+    );
   }
 
   // ============================================================================
@@ -967,11 +995,10 @@ class WebConvexClient implements IConvexClient {
     final hadToken = _currentAuthToken != null;
     _currentAuthToken = token;
 
-    debugPrint(
-      '[WebConvexClient] setAuth: '
-      '${hadToken ? "replacing" : "setting"} token → '
-      '${token != null ? "present" : "null"} '
-      '(wsReady=${_ws?.readyState == web.WebSocket.OPEN})',
+    config.logger(
+      ConvexLogLevel.info,
+      'web',
+      'setAuth: ${hadToken ? "replacing" : "setting"} token → ${token != null ? "present" : "null"} (wsReady=${_ws?.readyState == web.WebSocket.OPEN})',
     );
 
     if (token != null) {
@@ -987,61 +1014,125 @@ class WebConvexClient implements IConvexClient {
   Future<AuthHandle> setAuthWithRefresh({
     required Future<String?> Function() tokenFetcher,
     void Function(bool isAuthenticated)? onAuthChange,
-    String? initialToken,
   }) async {
-    // Use initialToken if provided, otherwise fetch one.
-    // When the caller already obtained a JWT (e.g. from restoreSession),
-    // passing it as initialToken avoids a redundant tokenFetcher call that
-    // would consume the single-use refresh token.
-    final token = initialToken ?? await tokenFetcher();
-    await setAuth(token: token);
+    // Buffer time before token expiry to trigger refresh.
+    const refreshBuffer = Duration(seconds: 60);
+    // Minimum refresh interval to prevent tight loops on errors.
+    const minRefreshInterval = Duration(seconds: 5);
+    // Default refresh interval when JWT can't be decoded.
+    const defaultRefreshInterval = Duration(minutes: 5);
 
-    if (onAuthChange != null) {
-      onAuthChange(token != null);
+    Timer? refreshTimer;
+    StreamSubscription<void>? authErrorSub;
+    var disposed = false;
+    // Track auth state to fire onAuthChange only on transitions, matching
+    // the Rust SDK's contract.
+    var wasAuthenticated = false;
+
+    void notifyTransition(bool isAuth) {
+      if (isAuth == wasAuthenticated) return;
+      wasAuthenticated = isAuth;
+      onAuthChange?.call(isAuth);
     }
 
-    // Listen for AuthError messages from the server (e.g. JWT expired)
-    // and automatically refresh the token.
-    StreamSubscription<bool>? authSub;
-    authSub = _authStateController.stream.listen((isAuthenticated) async {
-      if (!isAuthenticated) {
-        // Server reported auth failure — try to refresh
-        debugPrint(
-          '[WebConvexClient] Auth lost — requesting fresh token from bridge '
-          '(wsReady=${_ws?.readyState == web.WebSocket.OPEN}, '
-          'session=$_sessionId)',
-        );
-        try {
-          final newToken = await tokenFetcher();
-          if (newToken != null) {
-            await setAuth(token: newToken);
-            onAuthChange?.call(true);
-            debugPrint(
-              '[WebConvexClient] Token refresh succeeded',
-            );
-          } else {
-            onAuthChange?.call(false);
-            debugPrint(
-              '[WebConvexClient] Token refresh returned null — '
-              'bridge could not obtain a fresh Clerk token',
-            );
-          }
-        } catch (e) {
-          debugPrint(
-            'ERROR: [WebConvexClient] Token refresh failed: $e',
-          );
-          onAuthChange?.call(false);
-        }
+    // Fetch a token, push to WS, and schedule the next refresh based on the
+    // new token's exp claim. Called on initial setup, on scheduled refresh,
+    // and on server-initiated AuthError.
+    Future<void> refresh() async {
+      if (disposed) return;
+      refreshTimer?.cancel();
+
+      String? token;
+      try {
+        token = await tokenFetcher();
+      } catch (e) {
+        if (disposed) return;
+        config.logger(ConvexLogLevel.error, 'web', 'tokenFetcher threw: $e');
+        notifyTransition(false);
+        // Back off and retry — don't tight-loop on persistent errors.
+        refreshTimer = Timer(minRefreshInterval, refresh);
+        return;
       }
+      if (disposed) return;
+
+      await setAuth(token: token);
+
+      if (token == null) {
+        // Caller signalled sign-out. Stop scheduling — disposal will come
+        // through `handle.dispose()` from the consumer.
+        notifyTransition(false);
+        return;
+      }
+
+      notifyTransition(true);
+
+      // Schedule the next refresh from the JWT's exp.
+      final ttl = _decodeJwtTtl(token);
+      final Duration delay;
+      if (ttl != null) {
+        final adjusted = ttl - refreshBuffer;
+        delay = adjusted < minRefreshInterval ? minRefreshInterval : adjusted;
+        config.logger(
+          ConvexLogLevel.debug,
+          'web',
+          'Next token refresh in ${delay.inSeconds}s (JWT exp in ${ttl.inSeconds}s)',
+        );
+      } else {
+        delay = defaultRefreshInterval;
+        config.logger(
+          ConvexLogLevel.warn,
+          'web',
+          'JWT exp not decodable; defaulting to ${delay.inMinutes}-minute refresh interval',
+        );
+      }
+      refreshTimer = Timer(delay, refresh);
+    }
+
+    // Server-initiated AuthError → refresh now. Uses the private
+    // _authRefreshRequested stream rather than _authStateController so we
+    // ignore programmatic state changes (e.g. dispose → setAuth(null)).
+    authErrorSub = _authRefreshRequested.stream.listen((_) {
+      if (disposed) return;
+      config.logger(
+        ConvexLogLevel.warn,
+        'web',
+        'Server AuthError — refreshing token immediately',
+      );
+      refresh();
     });
 
+    // Kick off the initial fetch + schedule.
+    await refresh();
+
     return _WebAuthHandle(
-      isAuth: token != null,
+      isAuth: _currentAuthToken != null,
       onDispose: () async {
-        authSub?.cancel();
+        disposed = true;
+        refreshTimer?.cancel();
+        await authErrorSub?.cancel();
         await setAuth(token: null);
       },
     );
+  }
+
+  /// Decodes a JWT's `exp` claim and returns the time remaining until
+  /// expiry. Returns null if the token cannot be decoded.
+  static Duration? _decodeJwtTtl(String jwt) {
+    try {
+      final parts = jwt.split('.');
+      if (parts.length != 3) return null;
+      final payload =
+          jsonDecode(
+                utf8.decode(base64Url.decode(base64Url.normalize(parts[1]))),
+              )
+              as Map<String, dynamic>;
+      final exp = payload['exp'];
+      if (exp is! int) return null;
+      final expiresAt = DateTime.fromMillisecondsSinceEpoch(exp * 1000);
+      return expiresAt.difference(DateTime.now());
+    } catch (_) {
+      return null;
+    }
   }
 
   @override
@@ -1093,8 +1184,7 @@ class WebConvexClient implements IConvexClient {
 
   @override
   Future<bool> reconnect() async {
-    if (config.debugLogging)
-      debugPrint('=== [WebConvexClient] Manual reconnect requested ===');
+    config.logger(ConvexLogLevel.debug, 'web', 'Manual reconnect requested');
 
     // Close existing connection if any
     _ws?.close();
@@ -1116,7 +1206,7 @@ class WebConvexClient implements IConvexClient {
 
       return isConnected;
     } catch (e) {
-      debugPrint('ERROR: [WebConvexClient] Manual reconnect failed: $e');
+      config.logger(ConvexLogLevel.error, 'web', 'Manual reconnect failed: $e');
       return false;
     }
   }
@@ -1136,8 +1226,7 @@ class WebConvexClient implements IConvexClient {
   void dispose() {
     if (_isDisposed) return;
 
-    if (config.debugLogging)
-      debugPrint('=== [WebConvexClient] Disposing client ===');
+    config.logger(ConvexLogLevel.debug, 'web', 'Disposing client');
     _isDisposed = true;
 
     // Cancel reconnection timer
@@ -1152,6 +1241,7 @@ class WebConvexClient implements IConvexClient {
 
     // Close streams
     _authStateController.close();
+    _authRefreshRequested.close();
     _lifecycleController.close();
     _connectionStateController.close();
 
@@ -1159,8 +1249,7 @@ class WebConvexClient implements IConvexClient {
     _pendingRequests.clear();
     _subscriptions.clear();
 
-    if (config.debugLogging)
-      debugPrint('=== [WebConvexClient] Client disposed ===');
+    config.logger(ConvexLogLevel.debug, 'web', 'Client disposed');
   }
 }
 

--- a/lib/src/impl/convex_client_web.dart
+++ b/lib/src/impl/convex_client_web.dart
@@ -329,8 +329,6 @@ class WebConvexClient implements IConvexClient {
   /// Handles incoming WebSocket messages.
   void _handleMessage(String data) {
     try {
-      config.logger(ConvexLogLevel.debug, 'web', 'RAW MESSAGE: $data');
-
       final message = jsonDecode(data) as Map<String, dynamic>;
       final type = message['type'] as String?;
       final id = message['id'] as String?;
@@ -338,6 +336,7 @@ class WebConvexClient implements IConvexClient {
       // Skip Ping logging — server heartbeats every ~15s, pure protocol
       // noise. Same treatment in _sendMessage / _sendPong below.
       if (type != 'Ping') {
+        config.logger(ConvexLogLevel.debug, 'web', 'RAW MESSAGE: $data');
         config.logger(
           ConvexLogLevel.debug,
           'web',

--- a/lib/src/impl/convex_client_web.dart
+++ b/lib/src/impl/convex_client_web.dart
@@ -1,3 +1,31 @@
+// VENDORED & PATCHED — do not replace from pub.dev without re-applying fixes.
+// Patches applied on top of convex_flutter 3.0.1:
+//   1. _sendAuthMessage: correct Authenticate message format (tokenType/value/baseVersion)
+//   2. setAuth: pass null instead of '' for sign-out so tokenType:"None" is sent
+//   3. _sendMessage: queue messages when WebSocket is still CONNECTING (fixes startup race)
+//   4. _handleMutationResponse / _handleActionResponse: check success flag before
+//      treating null result as an error (void-returning functions return null legitimately)
+//   5. _handleMutationResponse / _handleActionResponse: emit ClientError (convexError
+//      or serverError) instead of generic Exception, matching native FFI error types
+//   6. _sendAuthMessage: use separate _identityVersion counter (not _querySetVersion)
+//      for Authenticate baseVersion — the Convex protocol tracks these independently
+//   7. _handleTransition: deliver null QueryUpdated values to subscribers (e.g. query
+//      returning null for unauthenticated user)
+//   8. onopen: sync _querySetVersion after flushing queued ModifyQuerySet messages
+//   9. All informational debugPrint calls gated behind config.debugLogging
+//  10. onopen: skip queued Authenticate messages during flush (onopen already sends
+//      auth from _currentAuthToken — flushing a duplicate causes a protocol error)
+//  11. onopen: re-register active subscriptions after reconnect so the new server
+//      session knows about them (previously subscriptions were lost on WS drop);
+//      excludes queryIds already sent via queue flush to avoid duplicate Add errors
+//  12. _handleFatalError: generate fresh sessionId and reset state before reconnect
+//      so the server creates a clean session instead of resuming stale state
+//  13. _sendConnectMessage: use _connectionCount (monotonic) instead of
+//      _reconnectAttempts for connectionCount field — the old code always sent 1
+//  14. _WebSubscription: store udfPath + args for re-registration on reconnect
+//  15. Always-on diagnostic logging for WS open/close, setAuth, AuthError,
+//      FatalError, and max-reconnect — not gated behind debugLogging
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
@@ -6,7 +34,8 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:web/web.dart' as web;
 import 'package:convex_flutter/src/impl/convex_client_interface.dart';
-import 'package:convex_flutter/src/rust/lib.dart' show WebSocketConnectionState, SubscriptionHandle, AuthHandle;
+import 'package:convex_flutter/src/rust/lib.dart'
+    show AuthHandle, ClientError, SubscriptionHandle, WebSocketConnectionState;
 import 'package:convex_flutter/src/connection_status.dart';
 import 'package:convex_flutter/src/convex_config.dart';
 import 'package:convex_flutter/src/app_lifecycle_event.dart';
@@ -62,14 +91,25 @@ class WebConvexClient implements IConvexClient {
   /// Query set version counter for ModifyQuerySet messages
   int _querySetVersion = 0;
 
+  /// Identity version counter for Authenticate messages (separate from querySetVersion)
+  int _identityVersion = 0;
+
   /// Pending requests waiting for responses (query, mutation, action)
   final Map<int, Completer<String>> _pendingRequests = {};
 
   /// Active subscriptions
   final Map<String, _WebSubscription> _subscriptions = {};
 
+  /// Messages queued while WebSocket is still connecting.
+  final List<Map<String, dynamic>> _messageQueue = [];
+
   /// Reconnection attempt counter
   int _reconnectAttempts = 0;
+
+  /// Monotonic connection counter (never reset). Used as the Convex protocol
+  /// `connectionCount` field so the server can distinguish first connection (0)
+  /// from reconnections (1, 2, …).
+  int _connectionCount = 0;
 
   /// Maximum reconnection attempts
   static const int _maxReconnectAttempts = 10;
@@ -93,7 +133,8 @@ class WebConvexClient implements IConvexClient {
   /// - Event listener registration
   /// - Lifecycle observer setup
   static Future<WebConvexClient> create(ConvexConfig config) async {
-    debugPrint('=== [WebConvexClient] Creating web client ===');
+    if (config.debugLogging)
+      debugPrint('=== [WebConvexClient] Creating web client ===');
 
     final client = WebConvexClient._(config);
 
@@ -106,14 +147,18 @@ class WebConvexClient implements IConvexClient {
       onLifecycleChange: (event) {
         client._lifecycleController.add(event);
         // Do NOT trigger reconnection on web - let WebSocket manage itself
-        debugPrint('=== [WebConvexClient] Lifecycle event: ${event.name} (no action on web) ===');
+        if (config.debugLogging)
+          debugPrint(
+            '=== [WebConvexClient] Lifecycle event: ${event.name} (no action on web) ===',
+          );
       },
     );
 
     // Establish WebSocket connection
     await client._connect();
 
-    debugPrint('=== [WebConvexClient] Client created successfully ===');
+    if (config.debugLogging)
+      debugPrint('=== [WebConvexClient] Client created successfully ===');
     return client;
   }
 
@@ -121,7 +166,8 @@ class WebConvexClient implements IConvexClient {
   Future<void> _connect() async {
     if (_isDisposed) return;
 
-    debugPrint('=== [WebConvexClient] Connecting to Convex ===');
+    if (config.debugLogging)
+      debugPrint('=== [WebConvexClient] Connecting to Convex ===');
 
     try {
       // Convert HTTPS to WSS URL with correct Convex sync endpoint
@@ -129,7 +175,8 @@ class WebConvexClient implements IConvexClient {
       final wsUrl = config.deploymentUrl.replaceFirst('https', 'wss');
       final fullUrl = '$wsUrl/api/sync';
 
-      debugPrint('=== [WebConvexClient] WebSocket URL: $fullUrl ===');
+      if (config.debugLogging)
+        debugPrint('=== [WebConvexClient] WebSocket URL: $fullUrl ===');
 
       // Update state to connecting
       _updateConnectionState(WebSocketConnectionState.connecting);
@@ -140,7 +187,8 @@ class WebConvexClient implements IConvexClient {
       // Setup event listeners
       _setupWebSocketListeners();
 
-      debugPrint('=== [WebConvexClient] WebSocket connection initiated ===');
+      if (config.debugLogging)
+        debugPrint('=== [WebConvexClient] WebSocket connection initiated ===');
     } catch (e) {
       debugPrint('ERROR: [WebConvexClient] Connection failed: $e');
       _scheduleReconnect();
@@ -154,9 +202,19 @@ class WebConvexClient implements IConvexClient {
 
     // Connection opened
     ws.onopen = (web.Event event) {
-      debugPrint('=== [WebConvexClient] WebSocket opened ===');
+      if (config.debugLogging)
+        debugPrint('=== [WebConvexClient] WebSocket opened ===');
+      debugPrint(
+        '[WebConvexClient] WS connected '
+        '(session=$_sessionId, connCount=$_connectionCount, '
+        'qsVersion=$_querySetVersion→0, idVersion=$_identityVersion→0, '
+        'queueLen=${_messageQueue.length}, '
+        'activeSubs=${_subscriptions.length}, '
+        'hasAuth=${_currentAuthToken != null})',
+      );
       _reconnectAttempts = 0; // Reset reconnection counter
       _querySetVersion = 0; // Reset query set version for new connection
+      _identityVersion = 0; // Reset identity version for new connection
       _updateConnectionState(WebSocketConnectionState.connected);
 
       // Send Connect handshake (required by Convex protocol)
@@ -166,6 +224,56 @@ class WebConvexClient implements IConvexClient {
       if (_currentAuthToken != null) {
         _sendAuthMessage(_currentAuthToken!);
       }
+
+      // Flush messages that were queued while WebSocket was connecting.
+      // Skip queued Authenticate messages — onopen already sent auth above.
+      // Sending a duplicate would cause a protocol version mismatch error.
+      //
+      // Track which queryIds were sent via queue flush so _resubscribeAll()
+      // doesn't duplicate them (duplicate Add → server InternalServerError).
+      final flushedQueryIds = <int>{};
+      if (_messageQueue.isNotEmpty) {
+        if (config.debugLogging)
+          debugPrint(
+            '=== [WebConvexClient] Flushing ${_messageQueue.length} queued message(s) ===',
+          );
+        final queued = List<Map<String, dynamic>>.from(_messageQueue);
+        _messageQueue.clear();
+        for (final msg in queued) {
+          if (msg['type'] == 'Authenticate') {
+            if (config.debugLogging)
+              debugPrint(
+                '=== [WebConvexClient] Skipping queued Authenticate (already sent in onopen) ===',
+              );
+            continue;
+          }
+          // Track version changes from queued ModifyQuerySet messages so
+          // _querySetVersion stays in sync with what the server processes.
+          if (msg['type'] == 'ModifyQuerySet') {
+            _querySetVersion = msg['newVersion'] as int;
+            // Record queryIds so _resubscribeAll can skip them.
+            final mods = msg['modifications'] as List?;
+            if (mods != null) {
+              for (final mod in mods) {
+                if (mod is Map && mod['queryId'] is int) {
+                  flushedQueryIds.add(mod['queryId'] as int);
+                }
+              }
+            }
+          }
+          _sendMessage(msg);
+        }
+      }
+
+      // Re-register active subscriptions that survived a reconnect.
+      // After a WS drop + reconnect, the server has a fresh session with no
+      // subscriptions. The _subscriptions map still holds Dart-side callbacks,
+      // but the server doesn't know about them. Re-send a single
+      // ModifyQuerySet with all active subscriptions so live data flows again.
+      //
+      // Skip queryIds that were already sent during queue flush above —
+      // duplicate Add for the same queryId causes server InternalServerError.
+      _resubscribeAll(excludeQueryIds: flushedQueryIds);
     }.toJS;
 
     // Connection closed
@@ -173,8 +281,12 @@ class WebConvexClient implements IConvexClient {
       final code = event.code;
       final reason = event.reason;
       final wasClean = event.wasClean;
-      debugPrint('=== [WebConvexClient] WebSocket closed ===');
-      debugPrint('=== [WebConvexClient] Close code: $code, reason: "$reason", wasClean: $wasClean ===');
+      debugPrint(
+        '[WebConvexClient] WS closed '
+        '(code=$code, reason="$reason", wasClean=$wasClean, '
+        'session=$_sessionId, qsVersion=$_querySetVersion, '
+        'activeSubs=${_subscriptions.length})',
+      );
       _updateConnectionState(WebSocketConnectionState.connecting);
 
       // Attempt reconnection if not disposed
@@ -207,13 +319,17 @@ class WebConvexClient implements IConvexClient {
   /// Handles incoming WebSocket messages.
   void _handleMessage(String data) {
     try {
-      debugPrint('=== [WebConvexClient] RAW MESSAGE: $data ===');
+      if (config.debugLogging)
+        debugPrint('=== [WebConvexClient] RAW MESSAGE: $data ===');
 
       final message = jsonDecode(data) as Map<String, dynamic>;
       final type = message['type'] as String?;
       final id = message['id'] as String?;
 
-      debugPrint('=== [WebConvexClient] Received message type: $type, id: $id ===');
+      if (config.debugLogging)
+        debugPrint(
+          '=== [WebConvexClient] Received message type: $type, id: $id ===',
+        );
 
       switch (type) {
         case 'Transition':
@@ -262,11 +378,40 @@ class WebConvexClient implements IConvexClient {
       final subscription = _subscriptions[queryId];
       if (subscription == null) continue;
 
-      final value = mod['value'];
-      if (value != null) {
-        final valueJson = jsonEncode(value);
-        subscription.onUpdate(valueJson);
+      // Check for error — Convex sends error information when the query
+      // fails (e.g. ArgumentValidationError, application-level ConvexError).
+      // The field name varies by Convex protocol version; check all known
+      // variants: errorMessage, error_message, errorData, error.
+      final errorMessage =
+          (mod['errorMessage'] ?? mod['error_message']) as String? ??
+          (mod['error'] is String ? mod['error'] as String : null);
+      final errorData =
+          mod['errorData'] as String? ??
+          (mod['error'] is Map ? jsonEncode(mod['error']) : null);
+
+      if (errorMessage != null) {
+        debugPrint(
+          '=== [WebConvexClient] Subscription error for queryId=$queryId: '
+          '$errorMessage (data: $errorData) ===',
+        );
+        subscription.onError(errorMessage, errorData);
+        continue;
       }
+
+      // If there's no value key at all AND no error, log for diagnostics
+      // (this shouldn't happen in normal protocol flow).
+      if (!mod.containsKey('value')) {
+        debugPrint(
+          '=== [WebConvexClient] Transition mod with no value or error for '
+          'queryId=$queryId. Keys: ${(mod as Map).keys.toList()} ===',
+        );
+        continue;
+      }
+
+      // Forward all values including null (e.g. query returning null for
+      // an unauthenticated user). The subscriber decodes via jsonDecode.
+      final valueJson = jsonEncode(mod['value']);
+      subscription.onUpdate(valueJson);
     }
   }
 
@@ -278,12 +423,12 @@ class WebConvexClient implements IConvexClient {
     final completer = _pendingRequests.remove(requestId);
     if (completer == null) return;
 
+    final success = message['success'] as bool? ?? false;
     final result = message['result'];
-    if (result != null) {
-      final resultJson = jsonEncode(result);
-      completer.complete(resultJson);
+    if (!success) {
+      completer.completeError(_buildClientError(result, 'Mutation failed'));
     } else {
-      completer.completeError(Exception('No result in mutation response'));
+      completer.complete(result != null ? jsonEncode(result) : 'null');
     }
   }
 
@@ -295,30 +440,64 @@ class WebConvexClient implements IConvexClient {
     final completer = _pendingRequests.remove(requestId);
     if (completer == null) return;
 
+    final success = message['success'] as bool? ?? false;
     final result = message['result'];
-    if (result != null) {
-      final resultJson = jsonEncode(result);
-      completer.complete(resultJson);
+    if (!success) {
+      completer.completeError(_buildClientError(result, 'Action failed'));
     } else {
-      completer.completeError(Exception('No result in action response'));
+      completer.complete(result != null ? jsonEncode(result) : 'null');
     }
+  }
+
+  /// Builds a [ClientError] from an error response, matching the native FFI
+  /// client's error types.
+  ///
+  /// If `errorData` is present (from a Convex `ConvexError`), emits
+  /// [ClientError.convexError]. Otherwise emits [ClientError.serverError].
+  ClientError _buildClientError(dynamic result, String fallback) {
+    final errorData = result is Map ? result['data'] : null;
+    if (errorData != null) {
+      return ClientError.convexError(data: jsonEncode(errorData));
+    }
+    final message = result is Map
+        ? (result['message']?.toString() ?? fallback)
+        : (result?.toString() ?? fallback);
+    return ClientError.serverError(msg: message);
   }
 
   /// Handles FatalError messages.
   void _handleFatalError(Map<String, dynamic> message) {
     final error = message['error'] as String? ?? 'Unknown fatal error';
-    debugPrint('FATAL ERROR: [WebConvexClient] $error');
+    debugPrint(
+      'FATAL ERROR: [WebConvexClient] $error '
+      '(session=$_sessionId, qsVersion=$_querySetVersion, '
+      'idVersion=$_identityVersion, activeSubs=${_subscriptions.length})',
+    );
 
-    // Close connection on fatal error
+    // Force a brand-new server session on the next reconnect by discarding
+    // the current sessionId. Without this, the reconnect reuses the same
+    // sessionId and the server tries to resume the broken session — which
+    // immediately triggers another FatalError (version mismatch).
+    _sessionId = null;
+    _connectionCount = 0;
+
+    // Close connection — the onclose handler will trigger _scheduleReconnect,
+    // which creates a fresh WS. The new onopen will generate a new sessionId
+    // and re-register all active subscriptions via _resubscribeAll().
     _ws?.close();
   }
 
   /// Handles AuthError messages.
   void _handleAuthError(Map<String, dynamic> message) {
     final error = message['error'] as String? ?? 'Authentication error';
-    debugPrint('AUTH ERROR: [WebConvexClient] $error');
+    final code = message['errorCode'] as String?;
+    debugPrint(
+      'AUTH ERROR: [WebConvexClient] $error '
+      '(code=$code, hasToken=${_currentAuthToken != null}, '
+      'session=$_sessionId)',
+    );
 
-    // Clear auth and notify
+    // Clear auth and notify — triggers token refresh via setAuthWithRefresh
     _authStateController.add(false);
   }
 
@@ -327,10 +506,11 @@ class WebConvexClient implements IConvexClient {
     try {
       _sendMessage({
         'type': 'Event',
-        'eventType': 'Pong',  // Required field
-        'event': null,  // Required field (can be null)
+        'eventType': 'Pong', // Required field
+        'event': null, // Required field (can be null)
       });
-      debugPrint('=== [WebConvexClient] Sent Pong ===');
+      if (config.debugLogging)
+        debugPrint('=== [WebConvexClient] Sent Pong ===');
     } catch (e) {
       debugPrint('ERROR: [WebConvexClient] Failed to send Pong: $e');
     }
@@ -339,18 +519,23 @@ class WebConvexClient implements IConvexClient {
   /// Sends Connect handshake message.
   void _sendConnectMessage() {
     try {
-      // Generate or reuse session ID (must be valid UUID format)
+      // Generate or reuse session ID (must be valid UUID format).
+      // _sessionId is reset to null in _handleFatalError so that a fresh
+      // session is created after protocol-level failures.
       _sessionId ??= _generateUuid();
 
       _sendMessage({
         'type': 'Connect',
         'sessionId': _sessionId,
         'maxObservedTimestamp': null,
-        'connectionCount': _reconnectAttempts + 1,
-        'lastCloseReason': null,  // Required field
-        'clientTs': DateTime.now().millisecondsSinceEpoch,  // Required field
+        'connectionCount': _connectionCount++,
+        'lastCloseReason': null, // Required field
+        'clientTs': DateTime.now().millisecondsSinceEpoch, // Required field
       });
-      debugPrint('=== [WebConvexClient] Sent Connect handshake ===');
+      if (config.debugLogging)
+        debugPrint(
+          '=== [WebConvexClient] Sent Connect handshake (session=$_sessionId, count=${_connectionCount - 1}) ===',
+        );
     } catch (e) {
       debugPrint('ERROR: [WebConvexClient] Failed to send Connect: $e');
     }
@@ -364,11 +549,15 @@ class WebConvexClient implements IConvexClient {
 
     // Generate random values for each segment
     final segment1 = random.nextInt(0x100000000); // 32 bits = 8 hex chars
-    final segment2 = random.nextInt(0x10000);      // 16 bits = 4 hex chars
-    final segment3 = random.nextInt(0x10000);      // 16 bits = 4 hex chars (we'll set version)
-    final segment4 = random.nextInt(0x10000);      // 16 bits = 4 hex chars (we'll set variant)
+    final segment2 = random.nextInt(0x10000); // 16 bits = 4 hex chars
+    final segment3 = random.nextInt(
+      0x10000,
+    ); // 16 bits = 4 hex chars (we'll set version)
+    final segment4 = random.nextInt(
+      0x10000,
+    ); // 16 bits = 4 hex chars (we'll set variant)
     final segment5a = random.nextInt(0x100000000); // 32 bits = 8 hex chars
-    final segment5b = random.nextInt(0x10000);     // 16 bits = 4 hex chars
+    final segment5b = random.nextInt(0x10000); // 16 bits = 4 hex chars
 
     // Set version 4 (bits 12-15 of segment3 = 0100)
     final version4 = (segment3 & 0x0FFF) | 0x4000;
@@ -377,19 +566,23 @@ class WebConvexClient implements IConvexClient {
     final variant = (segment4 & 0x3FFF) | 0x8000;
 
     // Combine segment5 parts into 12 hex digits
-    final segment5 = '${segment5a.toRadixString(16).padLeft(8, '0')}${segment5b.toRadixString(16).padLeft(4, '0')}';
+    final segment5 =
+        '${segment5a.toRadixString(16).padLeft(8, '0')}${segment5b.toRadixString(16).padLeft(4, '0')}';
 
     return '${segment1.toRadixString(16).padLeft(8, '0')}-'
-           '${segment2.toRadixString(16).padLeft(4, '0')}-'
-           '${version4.toRadixString(16).padLeft(4, '0')}-'
-           '${variant.toRadixString(16).padLeft(4, '0')}-'
-           '$segment5';
+        '${segment2.toRadixString(16).padLeft(4, '0')}-'
+        '${version4.toRadixString(16).padLeft(4, '0')}-'
+        '${variant.toRadixString(16).padLeft(4, '0')}-'
+        '$segment5';
   }
 
   /// Updates connection state and emits to stream.
   void _updateConnectionState(WebSocketConnectionState newState) {
     if (_currentConnectionState != newState) {
-      debugPrint('=== [WebConvexClient] State transition: ${_currentConnectionState.name} → ${newState.name} ===');
+      if (config.debugLogging)
+        debugPrint(
+          '=== [WebConvexClient] State transition: ${_currentConnectionState.name} → ${newState.name} ===',
+        );
       _currentConnectionState = newState;
       _connectionStateController.add(newState);
     }
@@ -402,7 +595,11 @@ class WebConvexClient implements IConvexClient {
     _reconnectTimer?.cancel();
 
     if (_reconnectAttempts >= _maxReconnectAttempts) {
-      debugPrint('ERROR: [WebConvexClient] Max reconnection attempts reached');
+      debugPrint(
+        'ERROR: [WebConvexClient] Max reconnection attempts reached '
+        '(activeSubs=${_subscriptions.length}, '
+        'pendingRequests=${_pendingRequests.length})',
+      );
       return;
     }
 
@@ -410,10 +607,16 @@ class WebConvexClient implements IConvexClient {
     final delay = _baseReconnectDelay * (1 << _reconnectAttempts.clamp(0, 5));
     _reconnectAttempts++;
 
-    debugPrint('=== [WebConvexClient] Scheduling reconnect attempt $_reconnectAttempts in ${delay.inSeconds}s ===');
+    if (config.debugLogging)
+      debugPrint(
+        '=== [WebConvexClient] Scheduling reconnect attempt $_reconnectAttempts in ${delay.inSeconds}s ===',
+      );
 
     _reconnectTimer = Timer(delay, () {
-      debugPrint('=== [WebConvexClient] Executing reconnect attempt $_reconnectAttempts ===');
+      if (config.debugLogging)
+        debugPrint(
+          '=== [WebConvexClient] Executing reconnect attempt $_reconnectAttempts ===',
+        );
       _connect();
     });
   }
@@ -424,28 +627,57 @@ class WebConvexClient implements IConvexClient {
   }
 
   /// Sends a message over WebSocket.
+  /// If the WebSocket is still connecting, the message is queued and sent
+  /// automatically once the connection opens.
   void _sendMessage(Map<String, dynamic> message) {
     final ws = _ws;
     if (ws == null || ws.readyState != web.WebSocket.OPEN) {
-      throw StateError('WebSocket not connected');
+      _messageQueue.add(message);
+      if (config.debugLogging)
+        debugPrint(
+          '=== [WebConvexClient] Queued message (WS not ready): ${message['type']} ===',
+        );
+      return;
     }
 
     final messageJson = jsonEncode(message);
-    debugPrint('=== [WebConvexClient] SENDING: $messageJson ===');
+    if (config.debugLogging)
+      debugPrint('=== [WebConvexClient] SENDING: $messageJson ===');
     ws.send(messageJson.toJS);
 
-    debugPrint('=== [WebConvexClient] Sent message: ${message['type']} (id: ${message['id']}) ===');
+    if (config.debugLogging)
+      debugPrint(
+        '=== [WebConvexClient] Sent message: ${message['type']} (id: ${message['id']}) ===',
+      );
   }
 
   /// Sends authentication message.
-  void _sendAuthMessage(String token) {
+  ///
+  /// Uses [_identityVersion] for baseVersion — this is a separate counter
+  /// from [_querySetVersion] (used by ModifyQuerySet). The Convex protocol
+  /// tracks query set and identity versions independently.
+  void _sendAuthMessage(String? token) {
     try {
-      // Send Authenticate message (Convex protocol)
-      _sendMessage({
-        'type': 'Authenticate',
-        'token': token,
-      });
-      debugPrint('=== [WebConvexClient] Auth token sent ===');
+      final baseVersion = _identityVersion;
+      _identityVersion++;
+
+      // Send Authenticate message (Convex protocol >=1.20)
+      if (token != null && token.isNotEmpty) {
+        _sendMessage({
+          'type': 'Authenticate',
+          'tokenType': 'User',
+          'value': token,
+          'baseVersion': baseVersion,
+        });
+      } else {
+        _sendMessage({
+          'type': 'Authenticate',
+          'tokenType': 'None',
+          'baseVersion': baseVersion,
+        });
+      }
+      if (config.debugLogging)
+        debugPrint('=== [WebConvexClient] Auth token sent ===');
     } catch (e) {
       debugPrint('ERROR: [WebConvexClient] Failed to send auth: $e');
     }
@@ -496,8 +728,8 @@ class WebConvexClient implements IConvexClient {
             'type': 'Add',
             'queryId': queryId,
             'udfPath': name,
-            'args': [args],  // Args must be array
-          }
+            'args': [args], // Args must be array
+          },
         ],
       });
 
@@ -528,8 +760,8 @@ class WebConvexClient implements IConvexClient {
       _sendMessage({
         'type': 'Mutation',
         'requestId': requestId,
-        'udfPath': name,  // Use udfPath instead of name
-        'args': [args],   // Args must be array, not object
+        'udfPath': name, // Use udfPath instead of name
+        'args': [args], // Args must be array, not object
       });
 
       return await completer.future.timeout(
@@ -559,8 +791,8 @@ class WebConvexClient implements IConvexClient {
       _sendMessage({
         'type': 'Action',
         'requestId': requestId,
-        'udfPath': name,  // Use udfPath instead of name
-        'args': [args],   // Args must be array, not object
+        'udfPath': name, // Use udfPath instead of name
+        'args': [args], // Args must be array, not object
       });
 
       return await completer.future.timeout(
@@ -587,11 +819,16 @@ class WebConvexClient implements IConvexClient {
     final queryId = _queryIdCounter++;
     final queryIdStr = queryId.toString();
 
-    // Create subscription record
+    // Create subscription record — store udfPath and args for re-registration
+    // after a WebSocket reconnect (the server loses all subscriptions on drop).
+    final serializedArgs = [args];
     final subscription = _WebSubscription(
       id: queryIdStr,
       onUpdate: onUpdate,
       onError: onError,
+      udfPath: name,
+      args: serializedArgs,
+      isSubscription: true,
     );
     _subscriptions[queryIdStr] = subscription;
 
@@ -608,13 +845,16 @@ class WebConvexClient implements IConvexClient {
           {
             'type': 'Add',
             'queryId': queryId,
-            'udfPath': name,  // Use udfPath instead of name
-            'args': [args],   // Args must be array, not object
-          }
+            'udfPath': name, // Use udfPath instead of name
+            'args': serializedArgs, // Args must be array, not object
+          },
         ],
       });
 
-      debugPrint('=== [WebConvexClient] Subscription created: queryId=$queryId ===');
+      if (config.debugLogging)
+        debugPrint(
+          '=== [WebConvexClient] Subscription created: queryId=$queryId ===',
+        );
 
       // Return handle for cancellation
       return _WebSubscriptionHandle(
@@ -633,7 +873,10 @@ class WebConvexClient implements IConvexClient {
     final subscription = _subscriptions.remove(queryIdStr);
     if (subscription == null) return;
 
-    debugPrint('=== [WebConvexClient] Unsubscribing: queryId=$queryIdStr ===');
+    if (config.debugLogging)
+      debugPrint(
+        '=== [WebConvexClient] Unsubscribing: queryId=$queryIdStr ===',
+      );
 
     try {
       final queryId = int.tryParse(queryIdStr);
@@ -648,15 +891,71 @@ class WebConvexClient implements IConvexClient {
         'baseVersion': baseVersion,
         'newVersion': newVersion,
         'modifications': [
-          {
-            'type': 'Remove',
-            'queryId': queryId,
-          }
+          {'type': 'Remove', 'queryId': queryId},
         ],
       });
     } catch (e) {
       debugPrint('ERROR: [WebConvexClient] Failed to send unsubscribe: $e');
     }
+  }
+
+  /// Re-registers all active long-lived subscriptions with the server.
+  ///
+  /// Called from onopen after a reconnect. The server session is fresh (version
+  /// 0, no subscriptions) but the Dart-side _subscriptions map still holds
+  /// callbacks from the previous connection. We send a single ModifyQuerySet
+  /// containing Add entries for every subscription so live data starts flowing
+  /// again without the UI needing to know about the reconnect.
+  void _resubscribeAll({Set<int> excludeQueryIds = const {}}) {
+    // Collect subscriptions that can be re-registered (have stored query info
+    // and are long-lived subscriptions, not one-shot queries).
+    // Skip any queryIds that were already sent during queue flush.
+    final resubs =
+        _subscriptions.values
+            .where(
+              (s) =>
+                  s.isSubscription &&
+                  s.udfPath != null &&
+                  !excludeQueryIds.contains(int.tryParse(s.id)),
+            )
+            .toList();
+
+    if (resubs.isEmpty) return;
+
+    if (config.debugLogging)
+      debugPrint(
+        '=== [WebConvexClient] Re-registering ${resubs.length} subscription(s) after reconnect ===',
+      );
+
+    final modifications = <Map<String, dynamic>>[];
+    for (final sub in resubs) {
+      final queryId = int.tryParse(sub.id);
+      if (queryId == null) continue;
+
+      modifications.add({
+        'type': 'Add',
+        'queryId': queryId,
+        'udfPath': sub.udfPath,
+        'args': sub.args ?? [{}],
+      });
+    }
+
+    if (modifications.isEmpty) return;
+
+    final baseVersion = _querySetVersion;
+    final newVersion = ++_querySetVersion;
+
+    _sendMessage({
+      'type': 'ModifyQuerySet',
+      'baseVersion': baseVersion,
+      'newVersion': newVersion,
+      'modifications': modifications,
+    });
+
+    if (config.debugLogging)
+      debugPrint(
+        '=== [WebConvexClient] Re-registered ${modifications.length} subscription(s) (version $baseVersion → $newVersion) ===',
+      );
   }
 
   // ============================================================================
@@ -665,13 +964,21 @@ class WebConvexClient implements IConvexClient {
 
   @override
   Future<void> setAuth({required String? token}) async {
+    final hadToken = _currentAuthToken != null;
     _currentAuthToken = token;
+
+    debugPrint(
+      '[WebConvexClient] setAuth: '
+      '${hadToken ? "replacing" : "setting"} token → '
+      '${token != null ? "present" : "null"} '
+      '(wsReady=${_ws?.readyState == web.WebSocket.OPEN})',
+    );
 
     if (token != null) {
       _sendAuthMessage(token);
       _authStateController.add(true);
     } else {
-      _sendAuthMessage(''); // Clear auth
+      _sendAuthMessage(null); // Clear auth
       _authStateController.add(false);
     }
   }
@@ -680,20 +987,58 @@ class WebConvexClient implements IConvexClient {
   Future<AuthHandle> setAuthWithRefresh({
     required Future<String?> Function() tokenFetcher,
     void Function(bool isAuthenticated)? onAuthChange,
+    String? initialToken,
   }) async {
-    // TODO: Implement token refresh for web
-    // For now, just fetch token once and set it
-    final token = await tokenFetcher();
+    // Use initialToken if provided, otherwise fetch one.
+    // When the caller already obtained a JWT (e.g. from restoreSession),
+    // passing it as initialToken avoids a redundant tokenFetcher call that
+    // would consume the single-use refresh token.
+    final token = initialToken ?? await tokenFetcher();
     await setAuth(token: token);
 
     if (onAuthChange != null) {
       onAuthChange(token != null);
     }
 
-    // Return a simple auth handle (no auto-refresh yet)
+    // Listen for AuthError messages from the server (e.g. JWT expired)
+    // and automatically refresh the token.
+    StreamSubscription<bool>? authSub;
+    authSub = _authStateController.stream.listen((isAuthenticated) async {
+      if (!isAuthenticated) {
+        // Server reported auth failure — try to refresh
+        debugPrint(
+          '[WebConvexClient] Auth lost — requesting fresh token from bridge '
+          '(wsReady=${_ws?.readyState == web.WebSocket.OPEN}, '
+          'session=$_sessionId)',
+        );
+        try {
+          final newToken = await tokenFetcher();
+          if (newToken != null) {
+            await setAuth(token: newToken);
+            onAuthChange?.call(true);
+            debugPrint(
+              '[WebConvexClient] Token refresh succeeded',
+            );
+          } else {
+            onAuthChange?.call(false);
+            debugPrint(
+              '[WebConvexClient] Token refresh returned null — '
+              'bridge could not obtain a fresh Clerk token',
+            );
+          }
+        } catch (e) {
+          debugPrint(
+            'ERROR: [WebConvexClient] Token refresh failed: $e',
+          );
+          onAuthChange?.call(false);
+        }
+      }
+    });
+
     return _WebAuthHandle(
       isAuth: token != null,
       onDispose: () async {
+        authSub?.cancel();
         await setAuth(token: null);
       },
     );
@@ -719,7 +1064,8 @@ class WebConvexClient implements IConvexClient {
       _connectionStateController.stream;
 
   @override
-  WebSocketConnectionState get currentConnectionState => _currentConnectionState;
+  WebSocketConnectionState get currentConnectionState =>
+      _currentConnectionState;
 
   @override
   bool get isConnected =>
@@ -747,11 +1093,16 @@ class WebConvexClient implements IConvexClient {
 
   @override
   Future<bool> reconnect() async {
-    debugPrint('=== [WebConvexClient] Manual reconnect requested ===');
+    if (config.debugLogging)
+      debugPrint('=== [WebConvexClient] Manual reconnect requested ===');
 
     // Close existing connection if any
     _ws?.close();
     _ws = null;
+
+    // Force a fresh server session on manual reconnect
+    _sessionId = null;
+    _connectionCount = 0;
 
     // Reset reconnection counter for manual reconnect
     _reconnectAttempts = 0;
@@ -785,7 +1136,8 @@ class WebConvexClient implements IConvexClient {
   void dispose() {
     if (_isDisposed) return;
 
-    debugPrint('=== [WebConvexClient] Disposing client ===');
+    if (config.debugLogging)
+      debugPrint('=== [WebConvexClient] Disposing client ===');
     _isDisposed = true;
 
     // Cancel reconnection timer
@@ -807,7 +1159,8 @@ class WebConvexClient implements IConvexClient {
     _pendingRequests.clear();
     _subscriptions.clear();
 
-    debugPrint('=== [WebConvexClient] Client disposed ===');
+    if (config.debugLogging)
+      debugPrint('=== [WebConvexClient] Client disposed ===');
   }
 }
 
@@ -817,10 +1170,24 @@ class _WebSubscription {
   final void Function(String) onUpdate;
   final void Function(String, String?) onError;
 
+  /// UDF path (e.g. "users:getCurrent") — stored for re-registration after reconnect.
+  final String? udfPath;
+
+  /// Serialized args (e.g. [{}]) — stored for re-registration after reconnect.
+  final List<dynamic>? args;
+
+  /// Whether this is a long-lived subscription (not a one-shot query).
+  /// One-shot queries auto-unsubscribe on first result and should NOT be
+  /// re-registered after a reconnect.
+  final bool isSubscription;
+
   _WebSubscription({
     required this.id,
     required this.onUpdate,
     required this.onError,
+    this.udfPath,
+    this.args,
+    this.isSubscription = false,
   });
 }
 
@@ -854,10 +1221,7 @@ class _WebAuthHandle implements AuthHandle {
   final Future<void> Function() onDispose;
   bool _isDisposed = false;
 
-  _WebAuthHandle({
-    required this.isAuth,
-    required this.onDispose,
-  });
+  _WebAuthHandle({required this.isAuth, required this.onDispose});
 
   @override
   bool isAuthenticated() => isAuth && !_isDisposed;

--- a/lib/src/impl/convex_client_web.dart
+++ b/lib/src/impl/convex_client_web.dart
@@ -335,11 +335,15 @@ class WebConvexClient implements IConvexClient {
       final type = message['type'] as String?;
       final id = message['id'] as String?;
 
-      config.logger(
-        ConvexLogLevel.debug,
-        'web',
-        'Received message type: $type, id: $id',
-      );
+      // Skip Ping logging — server heartbeats every ~15s, pure protocol
+      // noise. Same treatment in _sendMessage / _sendPong below.
+      if (type != 'Ping') {
+        config.logger(
+          ConvexLogLevel.debug,
+          'web',
+          'Received message type: $type, id: $id',
+        );
+      }
 
       switch (type) {
         case 'Transition':
@@ -519,7 +523,8 @@ class WebConvexClient implements IConvexClient {
     if (!_authRefreshRequested.isClosed) _authRefreshRequested.add(null);
   }
 
-  /// Sends Pong response to server Ping.
+  /// Sends Pong response to server Ping. Heartbeat housekeeping — no
+  /// logging on the happy path; failures still surface as errors.
   void _sendPong() {
     try {
       _sendMessage({
@@ -527,7 +532,6 @@ class WebConvexClient implements IConvexClient {
         'eventType': 'Pong', // Required field
         'event': null, // Required field (can be null)
       });
-      config.logger(ConvexLogLevel.debug, 'web', 'Sent Pong');
     } catch (e) {
       config.logger(ConvexLogLevel.error, 'web', 'Failed to send Pong: $e');
     }
@@ -663,14 +667,20 @@ class WebConvexClient implements IConvexClient {
     }
 
     final messageJson = jsonEncode(message);
-    config.logger(ConvexLogLevel.debug, 'web', 'SENDING: $messageJson');
+    // Skip Pong logging (paired with the Ping suppression in onmessage).
+    final isPong = message['type'] == 'Event' && message['eventType'] == 'Pong';
+    if (!isPong) {
+      config.logger(ConvexLogLevel.debug, 'web', 'SENDING: $messageJson');
+    }
     ws.send(messageJson.toJS);
 
-    config.logger(
-      ConvexLogLevel.debug,
-      'web',
-      'Sent message: ${message['type']} (id: ${message['id']})',
-    );
+    if (!isPong) {
+      config.logger(
+        ConvexLogLevel.debug,
+        'web',
+        'Sent message: ${message['type']} (id: ${message['id']})',
+      );
+    }
   }
 
   /// Sends authentication message.

--- a/lib/src/impl/convex_client_web.dart
+++ b/lib/src/impl/convex_client_web.dart
@@ -31,6 +31,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 import 'dart:math' as math;
 
 import 'package:web/web.dart' as web;
@@ -42,6 +43,36 @@ import 'package:convex_flutter/src/convex_config.dart';
 import 'package:convex_flutter/src/convex_logger.dart';
 import 'package:convex_flutter/src/app_lifecycle_event.dart';
 import 'package:convex_flutter/src/app_lifecycle_observer.dart';
+
+// Hot-restart safety stash.
+//
+// Flutter web hot-restart re-evaluates Dart but does not reset the JS engine.
+// The `.toJS` WebSocket event handlers we register in [_setupWebSocketListeners]
+// live in JS and hold strong references back into the Dart heap. After hot
+// restart they keep firing into now-orphaned Dart objects: parser closures
+// whose class tables got swapped (NoSuchMethodError on `json[$_get]`), and
+// StreamController listeners that try to setState on widgets attached to a
+// disposed EngineFlutterView.
+//
+// We stash a dispose callback on `globalThis` — which DOES survive hot
+// restart — so each new [WebConvexClient.create] can tear down its
+// predecessor before opening a fresh WebSocket.
+//
+// IMPORTANT: we cannot use `@JS('globalThis.foo') external` field bindings
+// here. DDC's hot-restart sequence clears those module-scoped externals back
+// to null (presumably to drop references to dead Dart isolates' closures).
+// Going through `globalContext.getProperty/setProperty` at the JS-property
+// level bypasses that reset — DDC has no reason to touch a property it
+// doesn't know Dart wrote.
+const String _stashKey = '__convexFlutterActiveDispose';
+
+JSFunction? _readStashedDispose() {
+  return globalContext.getProperty<JSFunction?>(_stashKey.toJS);
+}
+
+void _writeStashedDispose(JSFunction? value) {
+  globalContext.setProperty(_stashKey.toJS, value);
+}
 
 /// Web (pure Dart) implementation of Convex client.
 ///
@@ -144,7 +175,44 @@ class WebConvexClient implements IConvexClient {
   static Future<WebConvexClient> create(ConvexConfig config) async {
     config.logger(ConvexLogLevel.debug, 'web', 'Creating web client');
 
+    // Hot-restart safety: if a prior Dart run left a live WebConvexClient
+    // wired up in JS, tear it down before we open a new WebSocket. Without
+    // this, the orphaned client keeps receiving Transition frames and
+    // pushing them into a dead Dart heap (parse errors, "render a disposed
+    // EngineFlutterView" assertions). See the stash declaration above.
+    final priorDispose = _readStashedDispose();
+    if (priorDispose != null) {
+      try {
+        priorDispose.callAsFunction();
+        config.logger(
+          ConvexLogLevel.info,
+          'web',
+          'Disposed prior WebConvexClient from previous hot-restart cycle',
+        );
+      } catch (e) {
+        config.logger(
+          ConvexLogLevel.warn,
+          'web',
+          'Failed to dispose prior WebConvexClient: $e',
+        );
+      }
+      _writeStashedDispose(null);
+    }
+
     final client = WebConvexClient._(config);
+
+    // Stash a dispose callback in JS so the NEXT Dart run (after the next
+    // hot restart) can find and tear us down. The closure captures `client`
+    // strongly — that's intentional; the JS-side reference keeps the client
+    // reachable until the next create() invokes & clears the stash, which
+    // is exactly when we want the old client gone.
+    _writeStashedDispose((() {
+      try {
+        client.dispose();
+      } catch (_) {
+        // Swallow — caller's logger may itself be defunct after hot restart.
+      }
+    }).toJS);
 
     // Setup lifecycle observer
     // Note: On web, we don't reconnect on lifecycle events because:
@@ -599,6 +667,12 @@ class WebConvexClient implements IConvexClient {
 
   /// Updates connection state and emits to stream.
   void _updateConnectionState(WebSocketConnectionState newState) {
+    // Bail if dispose has run — the WebSocket's async close/error/open
+    // events can still fire after we close the underlying stream
+    // controller, and `.add()` on a closed broadcast controller throws.
+    // Without this guard we get "Bad state: Cannot add new events after
+    // calling close" out of every disposed client's onclose handler.
+    if (_isDisposed || _connectionStateController.isClosed) return;
     if (_currentConnectionState != newState) {
       config.logger(
         ConvexLogLevel.debug,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -116,6 +116,7 @@ abstract class RustLibApi extends BaseApi {
   MobileConvexClient crateMobileConvexClientNew({
     required String deploymentUrl,
     required String clientId,
+    required bool verboseLogging,
   });
 
   Future<void> crateMobileConvexClientOnWebsocketStateChange({
@@ -498,6 +499,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MobileConvexClient crateMobileConvexClientNew({
     required String deploymentUrl,
     required String clientId,
+    required bool verboseLogging,
   }) {
     return handler.executeSync(
       SyncTask(
@@ -505,6 +507,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(deploymentUrl, serializer);
           sse_encode_String(clientId, serializer);
+          sse_encode_bool(verboseLogging, serializer);
           return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
         },
         codec: SseCodec(
@@ -513,7 +516,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: null,
         ),
         constMeta: kCrateMobileConvexClientNewConstMeta,
-        argValues: [deploymentUrl, clientId],
+        argValues: [deploymentUrl, clientId, verboseLogging],
         apiImpl: this,
       ),
     );
@@ -521,7 +524,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateMobileConvexClientNewConstMeta => const TaskConstMeta(
     debugName: "MobileConvexClient_new",
-    argNames: ["deploymentUrl", "clientId"],
+    argNames: ["deploymentUrl", "clientId", "verboseLogging"],
   );
 
   @override

--- a/lib/src/rust/lib.dart
+++ b/lib/src/rust/lib.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 part 'lib.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `connected_client`, `decode_jwt_expiry`, `handle_direct_function_result`, `internal_action`, `internal_mutation`, `internal_set_auth`, `internal_subscribe`, `new`, `new`, `parse_json_args`
+// These functions are ignored because they are not marked as `pub`: `connected_client`, `decode_jwt_expiry`, `diagnose_connectivity`, `handle_direct_function_result`, `init_logging`, `internal_action`, `internal_mutation`, `internal_set_auth`, `internal_subscribe`, `new`, `new`, `parse_json_args`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `JwtClaims`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `fmt`, `fmt`, `fmt`, `from`, `from`
 
@@ -60,9 +60,11 @@ abstract class MobileConvexClient implements RustOpaqueInterface {
   factory MobileConvexClient({
     required String deploymentUrl,
     required String clientId,
+    required bool verboseLogging,
   }) => RustLib.instance.api.crateMobileConvexClientNew(
     deploymentUrl: deploymentUrl,
     clientId: clientId,
+    verboseLogging: verboseLogging,
   );
 
   /// Sets up WebSocket connection state change listener.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -3,3 +3,35 @@ import 'dart:convert';
 Map<String, String> buildArgs(Map<String, dynamic> record) {
   return {for (var entry in record.entries) entry.key: jsonEncode(entry.value)};
 }
+
+/// Normalize a JSON string so that whole-number doubles (e.g. `42.0`) become
+/// ints (`42`).
+///
+/// Dart's `jsonDecode` preserves the distinction between `1` (int) and `1.0`
+/// (double). The web Convex client delivers integers for whole numbers, but
+/// the Rust FFI client serialises all Convex `Float64` values with a decimal
+/// point. This mismatch causes `as int` casts in DTOs to throw on mobile.
+///
+/// By re-encoding the decoded-and-normalised value we ensure consumers see
+/// the same Dart types regardless of transport.
+String normalizeJsonNumbers(String jsonString) {
+  final decoded = jsonDecode(jsonString);
+  final normalized = _normalizeValue(decoded);
+  return jsonEncode(normalized);
+}
+
+dynamic _normalizeValue(dynamic value) {
+  if (value is double &&
+      value == value.truncateToDouble() &&
+      !value.isInfinite &&
+      !value.isNaN) {
+    return value.toInt();
+  }
+  if (value is List) {
+    return value.map(_normalizeValue).toList();
+  }
+  if (value is Map<String, dynamic>) {
+    return {for (final e in value.entries) e.key: _normalizeValue(e.value)};
+  }
+  return value;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: convex_flutter
 description: Multi-platform Convex backend integration for Flutter. Real-time WebSocket, subscriptions, auth, lifecycle management. Supports web (pure Dart) and native.
-version: 3.0.0
+version: 3.0.1
 repository: https://github.com/jkuldev/convex_flutter
 homepage: https://jkuldev.com
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_rust_bridge: ^2.11.1
+  flutter_rust_bridge: 2.11.1  # exact pin — must match Cargo.toml + generated bindings
   flutter_web_plugins:
     sdk: flutter
   freezed_annotation: ^3.1.0

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "convex"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c154dd74ee30e7c1757486657f5c6e961f3ad183cd490c1e71dab58b0ad0717f"
+checksum = "4ca2fbc7cfc35747ade0731b173cf72c70c7f72c4578440f9a77c871adaa1e2f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -258,18 +258,20 @@ dependencies = [
  "maplit",
  "once_cell",
  "parking_lot",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
 name = "convex_sync_types"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4089e2bd007e883e8a7a2ee44c3550969f15d471b7ec9c06976e91f1193cd0e3"
+checksum = "cba8235188b091cc50205a436bf6505cb386be208263fecdb4b62bd2b3c90a0a"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -282,22 +284,6 @@ dependencies = [
  "strum",
  "uuid",
 ]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -428,12 +414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,21 +460,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -606,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -813,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "imbl"
-version = "5.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4308a675e4cfc1920f36a8f4d8fb62d5533b7da106844bd1ec51c6f1fa94a0c"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
 dependencies = [
  "archery",
  "bitmaps",
@@ -823,6 +788,7 @@ dependencies = [
  "rand_core",
  "rand_xoshiro",
  "version_check",
+ "wide",
 ]
 
 [[package]]
@@ -871,12 +837,6 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -948,23 +908,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,60 +931,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-src"
-version = "300.5.4+3.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "oslog"
@@ -1094,12 +983,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -1233,7 +1116,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1255,25 +1138,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1282,18 +1153,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1307,12 +1178,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "schannel"
-version = "0.1.28"
+name = "safe_arch"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
- "windows-sys 0.61.2",
+ "bytemuck",
 ]
 
 [[package]]
@@ -1320,29 +1191,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -1499,19 +1347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
-dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,16 +1434,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,11 +1463,9 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
  "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.26.11",
@@ -1667,6 +1490,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1703,7 +1527,6 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand",
  "rustls",
  "rustls-pki-types",
@@ -1778,12 +1601,6 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1880,16 +1697,26 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.5",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,8 @@ flutter_rust_bridge = "=2.11.1"
 tokio = { version = "1", features = ["full"] }
 android_logger = { version = "0.14.1" }
 log = { version = "0.4.21" }
-convex = { version = "0.10.3", features = ["rustls-tls-webpki-roots"] }
+tracing = { version = "0.1", features = ["log"] }
+convex = { version = "0.10.4", default-features = false, features = ["rustls-tls-webpki-roots"] }
 anyhow = { version = "1.0.86" }
 thiserror = { version = "1.0.61" }
 tokio-stream = { features = [ "io-util", "sync" ], version = "0.1" }
@@ -22,6 +23,9 @@ async-once-cell = { version = "0.5.3" }
 serde_json = { version = "1.0.120" }
 serde = { version = "1.0", features = ["derive"] }
 base64 = { version = "0.21" }
+# rustls needs an explicit crypto provider — tokio-tungstenite doesn't
+# enable one. Without this, TLS handshakes hang silently on Android.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -506,11 +506,13 @@ fn wire__crate__MobileConvexClient_new_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_deployment_url = <String>::sse_decode(&mut deserializer);
             let api_client_id = <String>::sse_decode(&mut deserializer);
+            let api_verbose_logging = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             transform_result_sse::<_, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok(crate::MobileConvexClient::new(
                     api_deployment_url,
                     api_client_id,
+                    api_verbose_logging,
                 ))?;
                 Ok(output_ok)
             })())

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,7 +8,6 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-#[cfg(debug_assertions)]
 use android_logger::Config;
 use async_once_cell::OnceCell;
 use convex::{
@@ -23,12 +22,26 @@ use futures::{
     channel::oneshot::{self, Sender},
     pin_mut, select_biased, FutureExt, StreamExt,
 };
-use log::debug; // Logging for debugging purposes
-#[cfg(debug_assertions)]
-use log::LevelFilter;
+use log::{debug, error, LevelFilter};
 use parking_lot::Mutex;
 use base64::Engine;
 use serde::Deserialize;
+
+/// Initialise android_logger.  The `tracing` crate is compiled with its
+/// `log` feature, so tracing events from the Convex SDK automatically
+/// fall through to the `log` crate (and thus to android_logger) when no
+/// tracing subscriber is installed.
+///
+/// When `verbose` is false only warnings and errors are emitted, keeping
+/// logcat quiet in normal operation.
+fn init_logging(verbose: bool) {
+    let level = if verbose {
+        LevelFilter::Debug
+    } else {
+        LevelFilter::Warn
+    };
+    android_logger::init_once(Config::default().with_max_level(level));
+}
 
 // Custom error type for Convex client operations, exposed to Dart.
 #[derive(Debug, thiserror::Error)]
@@ -185,14 +198,14 @@ impl QuerySubscriber for CallbackSubscriberDartFn {
     fn on_update(&self, value: String) {
         let future = (self.on_update)(value);
         tokio::spawn(async move {
-            let _ = future.await; // Await the future, ignoring the result
+            future.await;
         });
     }
 
     fn on_error(&self, message: String, value: Option<String>) {
         let future = (self.on_error)(message, value);
         tokio::spawn(async move {
-            let _ = future.await;
+            future.await;
         });
     }
 }
@@ -211,9 +224,8 @@ pub struct MobileConvexClient {
 impl MobileConvexClient {
     /// Creates a new MobileConvexClient instance with the given deployment URL and client ID.
     #[frb(sync)]
-    pub fn new(deployment_url: String, client_id: String) -> MobileConvexClient {
-        #[cfg(debug_assertions)]
-        android_logger::init_once(Config::default().with_max_level(LevelFilter::Error));
+    pub fn new(deployment_url: String, client_id: String, verbose_logging: bool) -> MobileConvexClient {
+        init_logging(verbose_logging);
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
@@ -251,38 +263,28 @@ impl MobileConvexClient {
         &self,
         on_state_change: impl Fn(WebSocketConnectionState) -> DartFnFuture<()> + Send + Sync + 'static,
     ) -> Result<(), ClientError> {
-        println!("RUST: on_websocket_state_change() called");
+        debug!("on_websocket_state_change() called");
 
-        // Create tokio mpsc channel for receiving state changes from convex client
         let (state_tx, mut state_rx) = tokio::sync::mpsc::channel::<ConvexWebSocketState>(10);
-        println!("RUST: Created mpsc channel for state changes");
 
-        // Store sender for use when initializing the client
         {
             let mut sender = self.state_change_sender.lock();
             *sender = Some(state_tx);
-            println!("RUST: Stored state_tx in state_change_sender");
         }
 
-        // Spawn task to listen for state changes and call Dart callback
         let on_state_change = Arc::new(on_state_change);
-        println!("RUST: Spawning listener task for state changes");
         self.rt.spawn(async move {
-            println!("RUST: Listener task started, waiting for state changes");
+            debug!("WS state listener task started");
             while let Some(state) = state_rx.recv().await {
-                println!("RUST: Received state change from channel: {:?}", state);
+                debug!("WS state changed: {:?}", state);
                 let dart_state = WebSocketConnectionState::from(state);
-                println!("RUST: Converted to Dart state: {:?}", dart_state);
                 let callback = on_state_change.clone();
                 let future = (callback)(dart_state);
-                println!("RUST: Calling Dart callback");
                 let _ = future.await;
-                println!("RUST: Dart callback completed");
             }
-            println!("RUST: Listener task exiting (channel closed)");
+            debug!("WS state listener exiting (channel closed)");
         });
 
-        println!("RUST: on_websocket_state_change() returning");
         Ok(())
     }
 
@@ -291,31 +293,24 @@ impl MobileConvexClient {
         let url = self.deployment_url.clone();
         let state_sender = self.state_change_sender.lock().clone();
 
-        println!("RUST: connected_client() called with sender: {:?}", state_sender.is_some());
-
         self.client
             .get_or_try_init(async {
                 let client_id = self.client_id.to_owned();
 
-                // Build client directly without spawning a task
-                // This ensures callback is registered BEFORE connection starts
-                println!("RUST: Building ConvexClient directly (no task spawn)");
+                debug!("Building ConvexClient for {}", url);
                 let mut builder = ConvexClientBuilder::new(url.as_str())
                     .with_client_id(&client_id);
 
-                // Register state change callback BEFORE building
                 if let Some(sender) = state_sender {
-                    println!("RUST: Registering state change callback with builder");
                     builder = builder.with_on_state_change(sender);
                 } else {
-                    println!("RUST WARNING: No sender available - state changes will not be emitted");
+                    error!("No state_change sender — state changes will not be emitted");
                 }
 
-                println!("RUST: Calling builder.build() - connection will start now");
                 let result = builder.build().await;
                 match &result {
-                    Ok(_) => println!("RUST: ConvexClient built successfully"),
-                    Err(e) => println!("RUST ERROR: Failed to build ConvexClient: {:?}", e),
+                    Ok(_) => debug!("ConvexClient built successfully"),
+                    Err(e) => error!("Failed to build ConvexClient: {:?}", e),
                 }
                 result
             })


### PR DESCRIPTION
## Summary

- Flutter web hot-restart re-runs Dart but does **not** reset the JS engine. The `.toJS` WebSocket handlers registered by `WebConvexClient` survive every hot restart, keep firing into the orphaned Dart heap, and produce parse errors and \"Trying to render a disposed EngineFlutterView\" assertions that compound as zombies accumulate.
- Fix: stash a dispose callback on `globalThis` at `create()` time; next `create()` invokes it before opening a new WebSocket. Uses `dart:js_interop_unsafe` direct property access because DDC clears `@JS('globalThis.foo') external` module-scoped fields on hot restart.
- Also guards `_updateConnectionState` against the async race where onclose fires after dispose() has closed the underlying broadcast controller (caused \"Bad state: Cannot add new events after calling close\").

## Repro & verification 

Pre-fix: every hot restart while signed-in left the app in a broken state — multiple zombie clients receiving Convex Transitions, severe ErrorHandler logs, often required full page reload to recover.

Post-fix, verified with instance-id diagnostic instrumentation across two consecutive hot restarts:
- `DIAG stash on create: PRESENT` → `Disposed prior WebConvexClient from previous hot-restart cycle`
- All subsequent inbound messages handled by the current instance id only
- Zero SEVERE errors, zero zombie handlers, zero \"Bad state\" exceptions

## Test plan
- [ ] Hot restart 3+ times while subscriptions are active
- [ ] Verify no severe Flutter errors, no parse errors, no \"render a disposed EngineFlutterView\" assertions
- [ ] Verify \"Disposed prior WebConvexClient from previous hot-restart cycle\" appears once per restart after the first